### PR TITLE
resolve an issue if a user supplies an userPrincipleName (longer than…

### DIFF
--- a/certipy/target.py
+++ b/certipy/target.py
@@ -40,7 +40,9 @@ class Target:
             lmhash = nthash = ""
 
         self.domain = domain
-        self.username = username
+        # sam account names are limited to 20 characters, therefore if the user supplies a userPrincipalName,
+        # it needs to be stripped to 20 characters
+        self.username = username[:20]
         self.password = password
         self.remote_name = remote_name
         self.lmhash = lmhash


### PR DESCRIPTION
resolve an issue if a user supplies an userPrincipleName (longer than 20 characters)

The connection methods assumes a samAccountName(which is limited to 20 characters), in case of an user submitting an userPrincipleName, we need to limit its length to 20 characters in order to optain the samAccountName.