### PR TITLE
add technique ids from paper to output

### DIFF
--- a/certipy/find.py
+++ b/certipy/find.py
@@ -194,7 +194,7 @@ class CertificateTemplate:
         self._has_vulnerable_acl = None
         self._vulnerable_reasons = []
         self._enrollee = None
-
+        self._vulnerable_technique_ids = []
         self.entry = entry
         self.instance = instance
 
@@ -330,6 +330,7 @@ class CertificateTemplate:
             self._vulnerable_reasons.append(
                 "Template is owned by %s" % repr(self.instance.translate_sid(owner_sid))
             )
+            self._vulnerable_technique_ids.append("ESC4")
             self._is_vulnerable = True
 
         user_can_enroll = self.can_enroll
@@ -337,6 +338,7 @@ class CertificateTemplate:
 
         if vulnerable_acl:
             self._is_vulnerable = True
+            self._vulnerable_technique_ids.append("ESC4")
 
         if self.requires_manager_approval:
             return False
@@ -363,6 +365,7 @@ class CertificateTemplate:
                     "authentication" % repr(self._enrollee)
                 )
             )
+            self._vulnerable_technique_ids.append("ESC1")
             self._is_vulnerable = True
 
         has_dangerous_eku = (
@@ -377,6 +380,7 @@ class CertificateTemplate:
             self._vulnerable_reasons.append(
                 ("%s can enroll and template has dangerous EKU" % repr(self._enrollee))
             )
+            self._vulnerable_technique_ids.append("ESC2")
             self._is_vulnerable = True
 
         return self._is_vulnerable
@@ -454,7 +458,8 @@ class CertificateTemplate:
 
         if len(self._vulnerable_reasons) > 0:
             output["Vulnerable Reasons"] = self._vulnerable_reasons
-
+        if len(self._vulnerable_technique_ids) > 0:
+            output["Vulnerable Technique IDs"] = self._vulnerable_technique_ids
         return output
 
 


### PR DESCRIPTION
To ease reference to the paper [Certified_Pre-Owned](https://www.specterops.io/assets/resources/Certified_Pre-Owned.pdf), add the corresponding classes to the output.

![image](https://user-images.githubusercontent.com/34161284/140073243-32e61b75-11a7-4aeb-a7e5-2adef368ccfb.png)
