### PR TITLE
Fix error when no certificate templates are configured

### DIFF
--- a/certipy/find.py
+++ b/certipy/find.py
@@ -125,10 +125,13 @@ class EnrollmentService:
         validity = ca_certificate["validity"].native
         self.validity_start = str(validity["not_before"])
         self.validity_end = str(validity["not_after"])
-
-        self.certificate_templates = list(
-            map(lambda x: x.decode(), entry.get_raw("certificateTemplates"))
-        )
+        
+        if entry.get_raw("certificateTemplates"):
+            self.certificate_templates = list(
+                map(lambda x: x.decode(), entry.get_raw("certificateTemplates"))
+            )
+        else:
+            self.certificate_templates = []
 
         # EDITF_ATTRIBUTESUBJECTALTNAME2
         self.user_specifies_san = (edit_flags & 0x00040000) == 0x00040000


### PR DESCRIPTION
Hey,

There is an error in the find module when no templates are configured on a CA. As such, the `certificateTemplates` attribute does not exist and it breaks the parsing. Here is the stacktrace:

![image](https://user-images.githubusercontent.com/15702611/140102000-8c5524c6-7805-4845-8dce-0a54e5952f05.png)

I added a quick workaround, tell me if it's okay with you.