### PR TITLE
consolidate vulnerable reasons for has vulnerable acl

### DIFF
--- a/certipy/find.py
+++ b/certipy/find.py
@@ -295,7 +295,7 @@ class CertificateTemplate:
                 vulnerable_acl = True
         if vulnerable_acl:
             self._vulnerable_reasons.append(
-                f"{' & '.join(vulnerable_acl_sids)} has dangerous permissions"
+                "%s has dangerous permissions" % ' & '.join(vulnerable_acl_sids)
             )
         self._has_vulnerable_acl = vulnerable_acl
         return self._has_vulnerable_acl

--- a/certipy/find.py
+++ b/certipy/find.py
@@ -276,6 +276,7 @@ class CertificateTemplate:
 
         vulnerable_acl = False
         aces = self.security_descriptor.aces
+        vulnerable_acl_sids = []
         for sid, rights in aces.items():
             if not is_low_priv_sid(sid) and sid not in self.instance.user_sids:
                 continue
@@ -290,12 +291,12 @@ class CertificateTemplate:
                     ACTIVE_DIRECTORY_RIGHTS.WRITE_PROPERTY,
                 ]
             ):
-                self._vulnerable_reasons.append(
-                    "%s has dangerous permissions"
-                    % (repr(self.instance.translate_sid(sid)),)
-                )
+                vulnerable_acl_sids.append(repr(self.instance.translate_sid(sid)))
                 vulnerable_acl = True
-
+        if vulnerable_acl:
+            self._vulnerable_reasons.append(
+                f"{' & '.join(vulnerable_acl_sids)} has dangerous permissions"
+            )
         self._has_vulnerable_acl = vulnerable_acl
         return self._has_vulnerable_acl
 


### PR DESCRIPTION
Currently the has_vulnerable_acl is the only method adding multiple entries into _vulnerable_reasons for the same reason (with different usernames)

