### PR TITLE
Implement esc3 as seperate issue

### DIFF
--- a/certipy/find.py
+++ b/certipy/find.py
@@ -376,7 +376,7 @@ class CertificateTemplate:
         has_dangerous_eku = (
             any(
                 eku in self.extended_key_usage
-                for eku in ["Any Purpose", "Certificate Request Agent"]
+                for eku in ["Any Purpose"]
             )
             or len(self.extended_key_usage) == 0
         )
@@ -386,6 +386,14 @@ class CertificateTemplate:
                 ("%s can enroll and template has dangerous EKU" % repr(self._enrollee))
             )
             self._vulnerable_technique_ids.append("ESC2")
+            self._is_vulnerable = True
+
+        if user_can_enroll and "Certificate Request Agent" in self.extended_key_usage:
+            self._vulnerable_reasons.append(
+                ("%s can enroll and template has Certificate Request Agent EKU set, this can only be abused if a "
+                 "second template matches certain conditions" % repr(self._enrollee))
+            )
+            self._vulnerable_technique_ids.append("ESC3")
             self._is_vulnerable = True
 
         return self._is_vulnerable


### PR DESCRIPTION
Hi,

I created a new pull request and cleaned merge history to avoid conflicts and provide clean diffs.

You wrote in the last pull request:
> Thank you for your PR. First of all, there are some merge conflicts that needs to be resolved; I apologize if the mistake happened on my end. Secondly, this PR will give a false positive for the "auto" feature as the certificate is marked as vulnerable without the method being implemented to exploit. It will fail and continue with other certificate templates, but perhaps there is a better way to inform the user that the certificate might be vulnerable without automatically trying to exploit it in the "auto" feature.

The exact same issue should already happen before:

![image](https://user-images.githubusercontent.com/34161284/140765607-4615685b-1476-4671-ab3a-dbc510051cd5.png)
As you can see here, certificates with "Certificate Request Agent" eku were already reported before. I just moved this detection outside of `has_dangerous_eku` to have a better distinction as they are quite different to exploit.

The autoexploit function also fails for `vulnerable_acl` or `owner_sid` (ESC4) type vulnerabilities.

I would therefore suggest to merge this merge request, as their is no impact for "auto" (same issue was there before) and it now allows to reliable filter on different vulnerability types. 

So one could add a new check here:
![image](https://user-images.githubusercontent.com/34161284/140766617-e2ee6d3f-85aa-4dee-b842-e9fcdd8a93d1.png)
and filter `certificate_template._vulnerable_technique_ids` for implemented types.
