### PR TITLE
Fallback on default naming context when root naming context not avail…

### DIFF
--- a/certipy/find.py
+++ b/certipy/find.py
@@ -781,11 +781,25 @@ class Find:
             % self.ldap_connection.root_name_path,
             attributes=["name"],
         )
-
         if len(domains) == 0:
-            raise Exception(
-                "Could not find domain: %s" % self.ldap_connection.root_name_path
+            logging.debug(
+                    "Could not find domain root domain %s, trying default %s" 
+                    % (self.ldap_connection.root_name_path, 
+                    self.ldap_connection.default_path)
+                    )
+
+            domains = self.search(
+                "(&(objectClass=domain)(distinguishedName=%s))"
+                % self.ldap_connection.default_path,
+                attributes=["name"],
             )
+
+            if len(domains) == 0:
+                raise Exception(
+                    "Could not find domains: %s and %s" 
+                    % (self.ldap_connection.root_name_path,
+                    self.ldap_connection.default_path)
+                )
 
         self._domain = domains[0]
 


### PR DESCRIPTION
…able

When querying, the root naming context (top level domain) is used instead of the default one. In some cases, such as a child domain in a forest, we don't have access to the root domain, so trying to query the root naming context will result in raising an error: "Could not find domain DC=contenso,DC=com".

Here we still try to go for the root domain, but fallback on the default if it doesn't work. It may be nice to also add an option to specify the path we want to work with.