### PR TITLE
Fix: 'Namespace' object has no attribute 'json'

### DIFF
--- a/certipy/find.py
+++ b/certipy/find.py
@@ -471,6 +471,8 @@ class CertificateTemplate:
 class Find:
     def __init__(self, options: argparse.Namespace, target: Target = None):
         self.options = options
+        if not hasattr(self.options, "json"):
+            self.options.json = None
         if self.options.json:
             logging.getLogger().setLevel(logging.WARNING)
         if target is None:


### PR DESCRIPTION
When running the script with the *auto* mode, a `Find` object is created without the `-json` parameter. Hence, the attribute isn't present in the argsparse namespace. A check is needed to differenciate when launched in *find* mode or *auto* mode.
Here is the stacktrace:
![image](https://user-images.githubusercontent.com/15702611/146397831-8438a6ea-b803-4caf-a320-d67017d318a0.png)

This is a quickfix by looking before if the object `options` has a `json` attribute. It seems to be the only occurence of checking the `self.options.json` object when launched in the *auto* mode, so it could also be done by modifying the next line like so :

```
if hasattr(self.options, "json") and self.options.json
```

I don't know, you tell me !
