### PR TITLE
Fix case when ACE has neither "ObjectType" nor "InheritedObjectType"

### DIFF
--- a/certipy/security.py
+++ b/certipy/security.py
@@ -37,10 +37,12 @@ class ActiveDirectorySecurity:
                 self.aces[sid]["rights"] |= self.RIGHTS_TYPE(ace["Ace"]["Mask"]["Mask"])
 
             if ace["AceType"] == ldaptypes.ACCESS_ALLOWED_OBJECT_ACE.ACE_TYPE:
-                if ace["Ace"]["ObjectTypeLen"] == 0:
+                if ace["Ace"]["Flags"] == 2:
                     uuid = bin_to_string(ace["Ace"]["InheritedObjectType"]).lower()
-                else:
+                elif ace["Ace"]["Flags"] == 1:
                     uuid = bin_to_string(ace["Ace"]["ObjectType"]).lower()
+                else:
+                    continue
 
                 self.aces[sid]["extended_rights"].append(uuid)
 


### PR DESCRIPTION
Hi !

For some reason unknown to me, some ACEs can have neither a valid `ObjectType` nor `InheritedObjectType`. The current check will try to parse `InheritedObjectType` if `ObjectType` is empty, resulting in an error as `InheritedObjectType` will also be empty. The [right way to check this](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-dtyp/c79a383c-2b3f-4655-abe7-dcbb7ce0cfbe) seems to be checking the `Flags` field: a value of `0` indicates neither of these fields are valid, and the ACE can be ignored.

Cheers !