### PR TITLE
Add object SID handling

### DIFF
--- a/certipy/auth.py
+++ b/certipy/auth.py
@@ -35,6 +35,7 @@ from pyasn1.type.univ import noValue
 
 from certipy.certificate import (
     get_id_from_certificate,
+    get_object_sid_from_certificate,
     hash_digest,
     hashes,
     load_pfx,
@@ -120,6 +121,7 @@ class Authenticate:
 
         if not is_key_credential:
             id_type, identification = get_id_from_certificate(self.cert)
+            object_sid = get_object_sid_from_certificate(self.cert)
             cert_username, cert_domain = cert_id_to_parts(id_type, identification)
 
             if not any([cert_username, cert_domain]):
@@ -208,6 +210,15 @@ class Authenticate:
                     logging.error(
                         ("Verify that the domain %s matches the certificate %s: %s")
                         % (repr(domain), id_type, identification)
+                    )
+            elif "KDC_ERR_CERTIFICATE_MISMATCH" in str(e) and not is_key_credential:
+                logging.error(
+                    ("Object SID mismatch between certificate and user %s" % repr(username))
+                )
+                if object_sid is not None:
+                    logging.error(
+                        ("Verify that user %s has object SID %s")
+                        % (repr(username), repr(object_sid))
                     )
             else:
                 logging.error("Got error while trying to request TGT: %s" % str(e))

--- a/certipy/certificate.py
+++ b/certipy/certificate.py
@@ -24,6 +24,8 @@ NAME = "cert"
 
 PRINCIPAL_NAME = x509.ObjectIdentifier("1.3.6.1.4.1.311.20.2.3")
 
+NTDS_CA_SECURITY_EXT = x509.ObjectIdentifier("1.3.6.1.4.1.311.25.2")
+
 
 class EnrollmentNameValuePair(asn1core.Sequence):
     _fields = [
@@ -95,6 +97,22 @@ def get_id_from_certificate(
         pass
 
     return None, None
+
+
+def get_object_sid_from_certificate(
+    certificate: x509.Certificate,
+) -> Tuple[str, str]:
+    try:
+        object_sid = certificate.extensions.get_extension_for_oid(
+            NTDS_CA_SECURITY_EXT
+        )
+
+        sid = object_sid.value.value
+        return sid[sid.find(b'S-1-5'):].decode()
+    except:
+        pass
+
+    return None
 
 
 def create_pfx(key: rsa.RSAPrivateKey, cert: x509.Certificate) -> bytes:

--- a/certipy/relay.py
+++ b/certipy/relay.py
@@ -25,6 +25,7 @@ from certipy.certificate import (
     create_pfx,
     csr_to_pem,
     get_id_from_certificate,
+    get_object_sid_from_certificate,
     key_to_pem,
     pem_to_cert,
     pem_to_key,
@@ -311,7 +312,13 @@ class ADCSAttackClient(ProtocolAttack):
         if id_type is not None:
             logging.info("Got certificate with %s %s" % (id_type, repr(identification)))
         else:
-            logging.info("Got certficate without identification")
+            logging.info("Got certificate without identification")
+
+        object_sid = get_object_sid_from_certificate(cert)
+        if id_type is not None:
+            logging.info("Certificate object SID is %s" % repr(object_sid))
+        else:
+            logging.info("Certificate has not object SID")
 
         out = self.adcs_relay.out
         if out is None:

--- a/certipy/request.py
+++ b/certipy/request.py
@@ -18,6 +18,7 @@ from certipy.certificate import (
     csr_to_der,
     der_to_cert,
     get_id_from_certificate,
+    get_object_sid_from_certificate,
     key_to_pem,
     load_pfx,
     pem_to_key,
@@ -164,11 +165,18 @@ class Request:
             return False
 
         cert = der_to_cert(b"".join(response["pctbEncodedCert"]["pb"]))
+
         id_type, identification = get_id_from_certificate(cert)
         if id_type is not None:
             logging.info("Got certificate with %s %s" % (id_type, repr(identification)))
         else:
-            logging.info("Got certficate without identification")
+            logging.info("Got certificate without identification")
+
+        object_sid = get_object_sid_from_certificate(cert)
+        if id_type is not None:
+            logging.info("Certificate object SID is %s" % repr(object_sid))
+        else:
+            logging.info("Certificate has not object SID")
 
         out = self.out
         if out is None:
@@ -296,11 +304,18 @@ class Request:
             return False
 
         cert = der_to_cert(b"".join(response["pctbEncodedCert"]["pb"]))
+
         id_type, identification = get_id_from_certificate(cert)
         if id_type is not None:
             logging.info("Got certificate with %s %s" % (id_type, repr(identification)))
         else:
-            logging.info("Got certficate without identification")
+            logging.info("Got certificate without identification")
+
+        object_sid = get_object_sid_from_certificate(cert)
+        if id_type is not None:
+            logging.info("Certificate object SID is %s" % repr(object_sid))
+        else:
+            logging.info("Certificate has not object SID")
 
         out = self.out
         if out is None:


### PR DESCRIPTION
Hey @ly4k!

In this PR I would like to add some cases of handling this new `szOID_NTDS_CA_SECURITY_EXT` OID.

* If there's an object SID in the enrolled certificate, it will be printed during a request:

```
$ certipy req tinycorp.net/'testpc1$:UTFWnTqZV4mgGCkz'@172.22.0.5 -ca CATEXAS -template Machine -debug
Certipy v3.0.0 - by Oliver Lyak (ly4k)

[+] Generating RSA key
[*] Requesting certificate
[+] Trying to connect to endpoint: ncacn_np:172.22.0.5[\pipe\cert]
[+] Connected to endpoint: ncacn_np:172.22.0.5[\pipe\cert]
[*] Successfully requested certificate
[*] Request ID is 118
[*] Got certificate with DNS Host Name 'dc01.tinycorp.net'
[*] Certificate object SID is 'S-1-5-21-1230029644-1443616230-1161330039-2177'
[*] Saved certificate and private key to 'dc01.pfx'
```

* If the new `KDC_ERR_CERTIFICATE_MISMATCH` exception is araised, it will be handled correctly:

```
$ certipy auth -pfx testpc1.pfx -dc-ip 172.22.0.2 -debug
Certipy v3.0.0 - by Oliver Lyak (ly4k)

[*] Using principal: dc01$@tinycorp.net
[*] Trying to get TGT...
[+] Trying to connect to KDC at 172.22.0.2
[+] Server time (UTC): 2022-05-13 19:48:57
[-] Object SID mismatch between certificate and user 'dc01$'
[-] Verify that user 'dc01$' has object SID 'S-1-5-21-1230029644-1443616230-1161330039-2177'
```

Thanks for your awesome research!