### PR TITLE
Add missing % operator for string formatting

### DIFF
--- a/certipy/shadow.py
+++ b/certipy/shadow.py
@@ -92,7 +92,7 @@ class Shadow:
             )
         else:
             logging.error(
-                "Failed to update the Key Credentials for %s: "
+                "Failed to update the Key Credentials for %s: %s"
                 % (repr(user.get("sAMAccountName")), result["message"])
             )
         return False


### PR DESCRIPTION
There are two arguments given for string formatting, but only one % formatter. This causes an error when the message is supposed to be printed.