### PR TITLE
Fix the vulnerable template "Flags" attribute in order to work with Schannel (PassTheCert)

### DIFF
--- a/certipy/commands/template.py
+++ b/certipy/commands/template.py
@@ -29,13 +29,13 @@ PROTECTED_ATTRIBUTES = [
     "msPKI-Template-Minor-Revision",
 ]
 
-# SubCA template configuration with full control for 'Authenticated Users'
+# SubCA template configuration with full control for 'Authenticated Users' with zeroed flags
 CONFIGURATION_TEMPLATE = {
     "showInAdvancedViewOnly": [b"TRUE"],
     "nTSecurityDescriptor": [
         b"\x01\x00\x04\x9c0\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x14\x00\x00\x00\x02\x00\x1c\x00\x01\x00\x00\x00\x00\x00\x14\x00\xff\x01\x0f\x00\x01\x01\x00\x00\x00\x00\x00\x05\x0b\x00\x00\x00\x01\x05\x00\x00\x00\x00\x00\x05\x15\x00\x00\x00\xc8\xa3\x1f\xdd\xe9\xba\xb8\x90,\xaes\xbb\xf4\x01\x00\x00"  # Authenticated Users - Full Control
     ],
-    "flags": [b"131793"],
+    "flags": [b"0"],
     "pKIDefaultKeySpec": [b"2"],
     "pKIKeyUsage": [b"\x86\x00"],
     "pKIMaxIssuingDepth": [b"-1"],


### PR DESCRIPTION
Hi @ly4k!

We've noticed that, when exploiting **ESC4**, the `CT_FLAG_IS_CA` flag (present in the default [SubCA template](https://github.com/ly4k/Certipy/blob/7cadb2d63d7a4cd008a49f0533bf018b48f29482/certipy/template.py#L41)) generates a certificate that is not compatible with [PassTheCert](https://github.com/AlmondOffSec/PassTheCert), which uses **Schannel** for LDAP authentication.
![image](https://user-images.githubusercontent.com/22861294/182573655-e88224a4-afb5-48c6-9a9f-75cf51736aec.png)

Setting the [Flags ](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-crtd/6cc7eb79-3e84-477a-b398-b0ff2b68a6c0) attribute to 0 fixes the issue and makes the certificate work both with **PKINIT** and **Schannel**. You can specifically disable the `CT_FLAG_IS_CA` attribute only if you prefer, but it seems that the other flags are not required either.
![image](https://user-images.githubusercontent.com/22861294/182573431-4628a7aa-3a7f-4771-b4de-72f51642fec7.png)

More info about Schannel: https://offsec.almond.consulting/authenticating-with-certificates-when-pkinit-is-not-supported.html

Thanks!
