### PR TITLE
Added Ability to specify a password which will be used to encrypt the pfx file

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,7 @@ certificate request options:
                         Use a Certificate Request Agent certificate to request on behalf of another user
   -pfx pfx/p12 file name
                         Path to PFX for -on-behalf-of or -renew
+  -pfx-password PFX file password
   -key-size RSA key length
                         Length of RSA key. Default: 2048
   -archive-key          Send private key for Key Archival

--- a/certipy/commands/parsers/req.py
+++ b/certipy/commands/parsers/req.py
@@ -73,6 +73,7 @@ def add_subparser(subparsers: argparse._SubParsersAction) -> Tuple[str, Callable
 
     group = subparser.add_argument_group("output options")
     group.add_argument("-out", action="store", metavar="output file name")
+    group.add_argument("-pfx-password", action="store", metavar="PFX file password")
 
     connection_group = subparser.add_argument_group("connection options")
     connection_group.add_argument(

--- a/certipy/commands/parsers/req.py
+++ b/certipy/commands/parsers/req.py
@@ -53,6 +53,11 @@ def add_subparser(subparsers: argparse._SubParsersAction) -> Tuple[str, Callable
         help="Path to PFX for -on-behalf-of or -renew",
     )
     group.add_argument(
+        "-pfx-password", 
+        action="store", 
+        metavar="PFX file password"
+    )
+    group.add_argument(
         "-key-size",
         action="store",
         metavar="RSA key length",
@@ -73,7 +78,6 @@ def add_subparser(subparsers: argparse._SubParsersAction) -> Tuple[str, Callable
 
     group = subparser.add_argument_group("output options")
     group.add_argument("-out", action="store", metavar="output file name")
-    group.add_argument("-pfx-password", action="store", metavar="PFX file password")
 
     connection_group = subparser.add_argument_group("connection options")
     connection_group.add_argument(

--- a/certipy/commands/req.py
+++ b/certipy/commands/req.py
@@ -528,11 +528,11 @@ class Request:
         retrieve: int = 0,
         on_behalf_of: str = None,
         pfx: str = None,
+        pfx_password: str = None,
         key_size: int = None,
         archive_key: bool = False,
         renew: bool = False,
         out: str = None,
-        pfx_password: str = None,
         key: rsa.RSAPrivateKey = None,
         web: bool = False,
         port: int = None,
@@ -550,11 +550,11 @@ class Request:
         self.request_id = int(retrieve)
         self.on_behalf_of = on_behalf_of
         self.pfx = pfx
+        self.pfx_password = pfx_password
         self.key_size = key_size
         self.archive_key = archive_key
         self.renew = renew
         self.out = out
-        self.pfx_password = pfx_password
         self.key = key
 
         self.web = web

--- a/certipy/commands/req.py
+++ b/certipy/commands/req.py
@@ -532,6 +532,7 @@ class Request:
         archive_key: bool = False,
         renew: bool = False,
         out: str = None,
+        pfx_password: str = None,
         key: rsa.RSAPrivateKey = None,
         web: bool = False,
         port: int = None,
@@ -553,6 +554,7 @@ class Request:
         self.archive_key = archive_key
         self.renew = renew
         self.out = out
+        self.pfx_password = pfx_password
         self.key = key
 
         self.web = web
@@ -624,7 +626,7 @@ class Request:
             logging.info("Saved certificate to %s" % repr("%s.crt" % out))
         else:
             logging.info("Loaded private key from %s" % repr("%d.key" % request_id))
-            pfx = create_pfx(key, cert)
+            pfx = create_pfx(key, cert, self.pfx_password)
             with open("%s.pfx" % out, "wb") as f:
                 f.write(pfx)
             logging.info(
@@ -740,7 +742,7 @@ class Request:
 
             out = out.rstrip("$").lower()
 
-        pfx = create_pfx(key, cert)
+        pfx = create_pfx(key, cert, self.pfx_password)
 
         outfile = "%s.pfx" % out
 

--- a/certipy/lib/certificate.py
+++ b/certipy/lib/certificate.py
@@ -295,7 +295,7 @@ def get_object_sid_from_certificate(
 
 def create_pfx(key: rsa.RSAPrivateKey, cert: x509.Certificate, password: any) -> bytes:
     encryption = NoEncryption()
-    if not(password == None):
+    if (password != None):
         encryption = (
             PrivateFormat.PKCS12.encryption_builder().
             kdf_rounds(50000).

--- a/certipy/lib/certificate.py
+++ b/certipy/lib/certificate.py
@@ -293,13 +293,22 @@ def get_object_sid_from_certificate(
     return None
 
 
-def create_pfx(key: rsa.RSAPrivateKey, cert: x509.Certificate) -> bytes:
+def create_pfx(key: rsa.RSAPrivateKey, cert: x509.Certificate, password: any) -> bytes:
+    encryption = NoEncryption()
+    if not(password == None):
+        encryption = (
+            PrivateFormat.PKCS12.encryption_builder().
+            kdf_rounds(50000).
+            key_cert_algorithm(pkcs12.PBES.PBESv1SHA1And3KeyTripleDESCBC).
+            hmac_hash(hashes.SHA1()).build(password)
+        )
+
     return pkcs12.serialize_key_and_certificates(
         name=b"",
         key=key,
         cert=cert,
         cas=None,
-        encryption_algorithm=NoEncryption(),
+        encryption_algorithm=encryption,
     )
 
 

--- a/certipy/lib/certificate.py
+++ b/certipy/lib/certificate.py
@@ -4,7 +4,7 @@ import math
 import os
 import struct
 import sys
-from typing import Any, Callable, List, Tuple
+from typing import Callable, List, Tuple
 
 from asn1crypto import cms as asn1cms
 from asn1crypto import core as asn1core
@@ -293,7 +293,7 @@ def get_object_sid_from_certificate(
     return None
 
 
-def create_pfx(key: rsa.RSAPrivateKey, cert: x509.Certificate, password: Any) -> bytes:
+def create_pfx(key: rsa.RSAPrivateKey, cert: x509.Certificate, password=None) -> bytes:
     encryption = NoEncryption()
     if (password != None):
         encryption = (

--- a/certipy/lib/certificate.py
+++ b/certipy/lib/certificate.py
@@ -4,7 +4,7 @@ import math
 import os
 import struct
 import sys
-from typing import Callable, List, Tuple
+from typing import Any, Callable, List, Tuple
 
 from asn1crypto import cms as asn1cms
 from asn1crypto import core as asn1core
@@ -293,14 +293,14 @@ def get_object_sid_from_certificate(
     return None
 
 
-def create_pfx(key: rsa.RSAPrivateKey, cert: x509.Certificate, password: any) -> bytes:
+def create_pfx(key: rsa.RSAPrivateKey, cert: x509.Certificate, password: Any) -> bytes:
     encryption = NoEncryption()
     if (password != None):
         encryption = (
             PrivateFormat.PKCS12.encryption_builder().
             kdf_rounds(50000).
             key_cert_algorithm(pkcs12.PBES.PBESv1SHA1And3KeyTripleDESCBC).
-            hmac_hash(hashes.SHA1()).build(password)
+            hmac_hash(hashes.SHA1()).build(bytes(password, 'utf-8'))
         )
 
     return pkcs12.serialize_key_and_certificates(


### PR DESCRIPTION
Added Ability to specify a password which will be used to encrypt the pfx file, so it can be used as a certificate inside browsers, without editing it manually with OpenSSL