### PR TITLE
Fix template command doesn't update template when appending values to existing attributes

### DIFF
--- a/certipy/commands/template.py
+++ b/certipy/commands/template.py
@@ -1,6 +1,7 @@
 import argparse
 import collections
 import json
+from itertools import groupby
 from typing import Dict
 
 import ldap3
@@ -223,6 +224,14 @@ class Template:
         logging.info(
             "Updating certificate template %s" % repr(old_configuration.get("cn"))
         )
+
+        by_op = lambda item: item[1][0][0]
+        for op, group in groupby(sorted(changes.items(), key=by_op), by_op):
+            logging.debug("%s:" % op)
+            for item in list(group):
+                key = item[0]
+                value = item[1][0][1]
+                logging.debug("    %s: %s" % (key, repr(value)))
 
         result = self.connection.modify(
             old_configuration.get("distinguishedName"),

--- a/certipy/commands/template.py
+++ b/certipy/commands/template.py
@@ -1,4 +1,5 @@
 import argparse
+import collections
 import json
 from typing import Dict
 
@@ -189,7 +190,7 @@ class Template:
             if key in new_configuration:
                 old_values = old_configuration.get_raw(key)
                 new_values = new_configuration[key]
-                if all(list(map(lambda x: x in new_values, old_values))):
+                if collections.Counter(old_values) == collections.Counter(new_values):
                     continue
 
                 changes[key] = [


### PR DESCRIPTION
Hi!

I'm facing a bug when I use a custom configuration to update a template with "certipy template" command.
In the case, if `old_values = [  b"1" ]` and `new_values = [ b"1", b"2" ]`, the condition for skiping will be always true, so the command never updates the attribute.

Ref:
https://github.com/ly4k/Certipy/blob/17914230ce718bb6649bb2ec202c30e092872b52/certipy/commands/template.py#L189-L200


This PR fixed this bug by using `collections.Counter` to check if the new_values and old_values are same list.
Also add some debug information to print out what attributes have changed.


Thanks!


