### PR TITLE
Adds ESC11, missing IF_ENFORCEENCRYPTICERTREQUEST flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ Certipy is an offensive tool for enumerating and abusing Active Directory Certif
       - [ESC6](#esc6)
       - [ESC7](#esc7)
       - [ESC8](#esc8)
+      - [ESC9 & ESC10](#esc9_&_esc10)
+      - [ESC11](#esc11)
   - [Contact](#contact)
   - [Credits](#credits)
 
@@ -787,6 +789,13 @@ Certipy v4.0.0 - by Oliver Lyak (ly4k)
 #### ESC9 & ESC10
 
 ESC9 and ESC10 is not related to any specific Certipy commands or parameters, but can be abused with Certipy. See the [blog post](https://research.ifcr.dk/7237d88061f7) for more information.
+
+#### ESC11
+
+ESC11 can be abused with impacket's ntlmrelayx:
+
+```# ntlmrelayx.py -t rpc://ca.corp.local -rpc-mode ICPR -icpr-ca-name corp-DC-CA -smb2support
+```
 
 ## Contact
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Certipy is an offensive tool for enumerating and abusing Active Directory Certif
       - [ESC6](#esc6)
       - [ESC7](#esc7)
       - [ESC8](#esc8)
-      - [ESC9 & ESC10](#esc9_&_esc10)
+      - [ESC9 & ESC10](#esc9--esc10)
       - [ESC11](#esc11)
   - [Contact](#contact)
   - [Credits](#credits)
@@ -794,7 +794,8 @@ ESC9 and ESC10 is not related to any specific Certipy commands or parameters, bu
 
 ESC11 can be abused with impacket's ntlmrelayx:
 
-```# ntlmrelayx.py -t rpc://ca.corp.local -rpc-mode ICPR -icpr-ca-name corp-DC-CA -smb2support
+```bash
+$ ntlmrelayx.py -t rpc://ca.corp.local -rpc-mode ICPR -icpr-ca-name corp-DC-CA -smb2support
 ```
 
 ## Contact

--- a/certipy/commands/find.py
+++ b/certipy/commands/find.py
@@ -958,10 +958,10 @@ class Find:
                     % list_sids(enrollable_sids)
                 )
 
-            # ESC11
+            # ESC9
             if user_can_enroll and template.get("no_security_extension"):
                 vulnerabilities[
-                    "ESC11"
+                    "ESC9"
                 ] = "%s can enroll and template has no security extension" % list_sids(
                     enrollable_sids
                 )
@@ -1133,13 +1133,13 @@ class Find:
                 % ca.get("request_disposition")
             )
 
-        # ESC9
+        # ESC11
         if (
             ca.get("enforce_encrypt_icertrequest") == "Disabled"
             and ca.get("request_disposition") == "Issue"
         ):
             vulnerabilities[
-                "ESC9"
+                "ESC11"
             ] = "Encryption is not enforced for ICPR requests and Request Disposition is set to Issue"
 
         return vulnerabilities

--- a/certipy/commands/find.py
+++ b/certipy/commands/find.py
@@ -234,14 +234,16 @@ class Find:
         for ca in cas:
 
             if self.dc_only:
-                user_specified_san, request_disposition, security, web_enrollment = (
+                user_specified_san, request_disposition, enforce_encrypt_icertrequest, security, web_enrollment = (
+                    "Unknown",
                     "Unknown",
                     "Unknown",
                     None,
                     "Unknown",
                 )
             else:
-                user_specified_san, request_disposition, security = (
+                user_specified_san, request_disposition, enforce_encrypt_icertrequest, security = (
+                    "Unknown",
                     "Unknown",
                     "Unknown",
                     None,
@@ -256,7 +258,7 @@ class Find:
                     ca_target.target_ip = ca_target_ip
 
                     ca_service = CA(ca_target, ca=ca_name)
-                    edit_flags, request_disposition, security = ca_service.get_config()
+                    edit_flags, request_disposition, interface_flags, security = ca_service.get_config()
 
                     if request_disposition:
                         request_disposition = (
@@ -272,6 +274,14 @@ class Find:
                         )
                     else:
                         user_specified_san = "Unknown"
+
+                    if interface_flags:
+                        enforce_encrypt_icertrequest = (interface_flags & 0x00000200) == 0x00000200
+                        enforce_encrypt_icertrequest = (
+                            "Enabled" if enforce_encrypt_icertrequest else "Disabled"
+                        )
+                    else:
+                        enforce_encrypt_icertrequest = "Unknown"
 
                 except Exception as e:
                     logging.warning(
@@ -291,6 +301,7 @@ class Find:
 
             ca.set("user_specified_san", user_specified_san)
             ca.set("request_disposition", request_disposition)
+            ca.set("enforce_encrypt_icertrequest", enforce_encrypt_icertrequest)
             ca.set("security", security)
             ca.set("web_enrollment", web_enrollment)
 
@@ -1035,6 +1046,7 @@ class Find:
             "web_enrollment": "Web Enrollment",
             "user_specified_san": "User Specified SAN",
             "request_disposition": "Request Disposition",
+            "enforce_encrypt_icertrequest": "Enforce Encryption for ICRT Requests",
         }
 
         if ca_properties is None:
@@ -1120,6 +1132,15 @@ class Find:
                 "Web Enrollment is enabled and Request Disposition is set to %s"
                 % ca.get("request_disposition")
             )
+
+        # ESC9
+        if (
+            ca.get("enforce_encrypt_icertrequest") == "Disabled"
+            and ca.get("request_disposition") == "Issue"
+        ):
+            vulnerabilities[
+                "ESC9"
+            ] = "Encryption is not enforced for ICPR requests and Request Disposition is set to Issue"
 
         return vulnerabilities
 

--- a/certipy/commands/find.py
+++ b/certipy/commands/find.py
@@ -958,10 +958,10 @@ class Find:
                     % list_sids(enrollable_sids)
                 )
 
-            # ESC9
+            # ESC11
             if user_can_enroll and template.get("no_security_extension"):
                 vulnerabilities[
-                    "ESC9"
+                    "ESC11"
                 ] = "%s can enroll and template has no security extension" % list_sids(
                     enrollable_sids
                 )

--- a/certipy/commands/find.py
+++ b/certipy/commands/find.py
@@ -1046,7 +1046,7 @@ class Find:
             "web_enrollment": "Web Enrollment",
             "user_specified_san": "User Specified SAN",
             "request_disposition": "Request Disposition",
-            "enforce_encrypt_icertrequest": "Enforce Encryption for ICRT Requests",
+            "enforce_encrypt_icertrequest": "Enforce Encryption for Requests",
         }
 
         if ca_properties is None:


### PR DESCRIPTION
This adds a check over RRPor CSRA for the IF_ENFORCEENCRYPTICERTREQUEST flag.

See https://blog.compass-security.com/2022/11/relaying-to-ad-certificate-services-over-rpc/