### PR TITLE
Added minimum RSA key length to template attributes

### DIFF
--- a/certipy/commands/find.py
+++ b/certipy/commands/find.py
@@ -720,6 +720,7 @@ class Find:
                 "msPKI-Enrollment-Flag",
                 "msPKI-Private-Key-Flag",
                 "msPKI-Certificate-Name-Flag",
+                "msPKI-Minimal-Key-Size",
                 "msPKI-RA-Signature",
                 "pKIExtendedKeyUsage",
                 "nTSecurityDescriptor",
@@ -818,6 +819,7 @@ class Find:
             "authorized_signatures_required": "Authorized Signatures Required",
             "validity_period": "Validity Period",
             "renewal_period": "Renewal Period",
+            "msPKI-Minimal-Key-Size": "Minimum RSA Key Length"
         }
 
         if template_properties is None:


### PR DESCRIPTION
I encountered a situation during an engagement where the certificate template had a different minimum private key length requirement than the default of 2048. Therefore, this PR includes the key length as part of the template attributes so users can identify and specify the key length in certificate requests. 

Reference - https://learn.microsoft.com/en-us/windows/win32/adschema/a-mspki-minimal-key-size