### PR TITLE
[Enhancement] Adding Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM python:3.8-alpine as compile
+WORKDIR /opt
+RUN apk add --no-cache git gcc musl-dev python3-dev libffi-dev openssl-dev cargo
+RUN python3 -m pip install virtualenv
+RUN virtualenv -p python venv
+ENV PATH="/opt/venv/bin:$PATH"
+RUN git clone --depth 1 https://github.com/HuskyHacks/Certipy.git
+WORKDIR /opt/Certipy
+RUN python3 setup.py install
+RUN pip3 install pycryptodome
+
+FROM python:3.8-alpine
+COPY --from=compile /opt/venv /opt/venv
+ENV PATH="/opt/venv/bin:$PATH"
+WORKDIR /opt/Certipy
+ENTRYPOINT ["certipy"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ RUN apk add --no-cache git gcc musl-dev python3-dev libffi-dev openssl-dev cargo
 RUN python3 -m pip install virtualenv
 RUN virtualenv -p python venv
 ENV PATH="/opt/venv/bin:$PATH"
-RUN git clone --depth 1 https://github.com/HuskyHacks/Certipy.git
+RUN git clone --depth 1 https://github.com/ly4k/Certipy.git
 WORKDIR /opt/Certipy
 RUN python3 setup.py install
 RUN pip3 install pycryptodome

--- a/README.md
+++ b/README.md
@@ -36,6 +36,19 @@ or
 ```bash
 python3 /path/to/Certipy/setup.py install
 ```
+### Docker
+
+Build the container:
+
+```
+$ sudo docker build -t certipy .
+```
+
+Run the container with arguments and mount a volume to collect the outfiles:
+
+```
+$ sudo docker run -v $(pwd):/opt/Certipy -it certipy find -u [username] -p [password] -dc-ip [dc-ip]
+```
 
 ## Usage
 


### PR DESCRIPTION
Hi!

If there's any interest in a dockerized version, I've created a Dockerfile and edited the README with instructions. I hit some dependency snags when working with Certipy and sought to solve them with Docker. The dockerfile is derived from the dockerfiles of Impacket and CrackMapExec.

The mounted volume is good for collecting all of the artifacts. You should also still be able to publish a port for `certipy relay` but I have not tested that yet.

This set up may need some testing to make sure it works in all use cases but so far so good for me! (Tested w. ESC1, 2, 3, Golden Certificate)