### PR TITLE
Allow weak TLS ciphers in LDAP connection

### DIFF
--- a/certipy/commands/auth.py
+++ b/certipy/commands/auth.py
@@ -279,6 +279,7 @@ class Authenticate:
             local_private_key_file=key_file.name,
             local_certificate_file=cert_file.name,
             validate=ssl.CERT_NONE,
+            ciphers='ALL:@SECLEVEL=0',
         )
 
         host = self.target.target_ip

--- a/certipy/lib/ldap.py
+++ b/certipy/lib/ldap.py
@@ -84,7 +84,8 @@ class LDAPConnection:
             return
         else:
             if self.scheme == "ldaps":
-                tls = ldap3.Tls(validate=ssl.CERT_NONE, version=version)
+                tls = ldap3.Tls(validate=ssl.CERT_NONE, version=version,
+                                ciphers='ALL:@SECLEVEL=0')
                 ldap_server = ldap3.Server(
                     self.target.target_ip,
                     use_ssl=True,


### PR DESCRIPTION
This is similar to the change in the Impacket repository: https://github.com/SecureAuthCorp/impacket/pull/1449

Some domain controllers are using very weak ciphers, which are rejected by the ssl library of Python3.10 by default. This sets the cipher settings to the lowest value. Just like the certificate is currently not validated at all, we don't really care about weak ciphers.

The same caveat about this bug in ldap3 applies:
https://github.com/cannatag/ldap3/pull/1067