### PR TITLE
Fix authentication request in multidomain environment

### DIFF
--- a/certipy/commands/shadow.py
+++ b/certipy/commands/shadow.py
@@ -200,7 +200,7 @@ class Shadow:
 
         authenticate = Authenticate(self.target, cert=cert, key=key)
         authenticate.authenticate(
-            username=user.get("sAMAccountName"), is_key_credential=True
+            username=user.get("sAMAccountName"), is_key_credential=True, domain=self.connection.domain
         )
 
         logging.info(


### PR DESCRIPTION
The modification fix an issue where the domain used to authenticate the target account is set to the querying user's domain.

For instance if _myuser.users.domain.local_ wants to create shadow credential for _mycomputer$.computers.domain.local_ by querying the _computers.domain.local domain_ controller where _mycomputer$_ account is located, then the current code would generate authentication request for  _mycomputer$.users.domain.local_. It would lead to an _KDC_ERR_WRONG_REALM_ error.

The modification ensure the authentication request is done using the domain where the _mycomputer$_ object has been found. In the previous example the new code would generate authentication request for  _mycomputer$@computers.domain.local_ as the LDAP request has been issued to the _computers.domain.local domain_ controller.