### PR TITLE
Fix value error when ms-DS-MachineAccountQuota is not found

### DIFF
--- a/certipy/lib/ldap.py
+++ b/certipy/lib/ldap.py
@@ -301,7 +301,7 @@ class LDAPConnection:
             ],
         )
         if len(results) != 1:
-            return None
+            return 0
 
         result = results[0]
         machine_account_quota = result.get("ms-DS-MachineAccountQuota")


### PR DESCRIPTION
I had a case where certipy crashed because ms-DS-MachineAccountQuota did not exist. This resulted in the function returning None where an integer was expected, resulting in a value error