### PR TITLE
Fix for python 3.11

### DIFF
--- a/certipy/commands/find.py
+++ b/certipy/commands/find.py
@@ -778,7 +778,10 @@ class Find:
             is_inherited = rights["inherited"]
             principal = self.connection.lookup_sid(sid)
 
-            standard_rights = rights["rights"].to_list()
+            try:
+                standard_rights = list(rights["rights"])
+            except:
+                standard_rights = rights["rights"].to_list()
 
             for right in standard_rights:
                 aces.append(
@@ -1076,7 +1079,10 @@ class Find:
             for sid, rights in security.aces.items():
                 if self.hide_admins and is_admin_sid(sid):
                     continue
-                ca_rights = rights["rights"].to_list()
+                try:
+                    ca_rights = list(rights["rights"])
+                except:
+                    ca_rights = rights["rights"].to_list()
                 for ca_right in ca_rights:
                     if ca_right not in access_rights:
                         access_rights[ca_right] = [

--- a/certipy/lib/structs.py
+++ b/certipy/lib/structs.py
@@ -13,7 +13,10 @@ class IntFlag(enum.IntFlag):
         return members
 
     def to_str_list(self):
-        return list(map(lambda x: str(x), self.to_list()))
+        try:
+            return list(map(lambda x: str(x), list(self)))
+        except:
+            return list(map(lambda x: str(x), self.to_list()))
 
     def __str__(self):
         cls = self.__class__


### PR DESCRIPTION
This fixes the issue with _decompose calls...

Essentially, if python supports converting the IntFlags into a list, we do it, otherwise we fall back to old behavior.

See #108 for details.