### PR TITLE
Update python requirments

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ setup(
     url="https://github.com/ly4k/Certipy",
     long_description=readme,
     long_description_content_type="text/markdown",
+    python_requires='<3.11',
     install_requires=[
         "asn1crypto",
         "cryptography>=37.0",


### PR DESCRIPTION
As of python 3.11, enum module doesn't have a '_decompose'  attribute. Forcing python 3.10 on install will fix the problems.