### PR TITLE
Prefer Hostname in AD CS Web API URL

### DIFF
--- a/certipy/commands/req.py
+++ b/certipy/commands/req.py
@@ -288,7 +288,7 @@ class WebRequestInterface(RequestInterface):
         session.auth = HttpNtlmAuth(principal, password)
         session.verify = False
 
-        base_url = "%s://%s:%i" % (scheme, self.target.target_ip, port)
+        base_url = "%s://%s:%i" % (scheme, self.target.remote_name, port)
         logging.info("Checking for Web Enrollment on %s" % repr(base_url))
 
         session.headers["User-Agent"] = None
@@ -317,7 +317,7 @@ class WebRequestInterface(RequestInterface):
         if not success:
             scheme = "https" if scheme == "http" else "http"
             port = 80 if scheme == "http" else 443
-            base_url = "%s://%s:%i" % (scheme, self.target.target_ip, port)
+            base_url = "%s://%s:%i" % (scheme, self.target.remote_name, port)
             logging.info(
                 "Trying to connect to Web Enrollment interface %s" % repr(base_url)
             )


### PR DESCRIPTION
When a certificate is requested with `-web`, the AD CS web API is currently accessed using IP addresses with the hostname in the host header. This can sometimes fail, probably because IIS checks the TLS-SNI instead of the host header depending on the configuration. With this PR, the hostname is used in the url passed to `requests` such that the TLS-SNI can be set accordingly. As I understand it, `self.target.remote_name` contains the IP if the hostname cannot be determined, so it should not break anything.