### PR TITLE
added csv export option

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ The `find` command is useful for enumerating AD CS certificate templates, certif
 ```
 Certipy v4.0.0 - by Oliver Lyak (ly4k)
 
-usage: certipy find [-h] [-debug] [-bloodhound] [-old-bloodhound] [-text] [-stdout] [-json] [-output prefix] [-enabled] [-dc-only] [-vulnerable] [-hide-admins] [-scheme ldap scheme] [-dc-ip ip address] [-target-ip ip address] [-target dns/ip address] [-ns nameserver] [-dns-tcp]
+usage: certipy find [-h] [-debug] [-bloodhound] [-old-bloodhound] [-text] [-stdout] [-json] [-csv] [-output prefix] [-enabled] [-dc-only] [-vulnerable] [-hide-admins] [-scheme ldap scheme] [-dc-ip ip address] [-target-ip ip address] [-target dns/ip address] [-ns nameserver] [-dns-tcp]
                     [-timeout seconds] [-u username@domain] [-p password] [-hashes [LMHASH:]NTHASH] [-k] [-sspi] [-aes hex key] [-no-pass]
 
 optional arguments:
@@ -86,6 +86,7 @@ output options:
   -text                 Output result as text
   -stdout               Output result as text to stdout
   -json                 Output result as JSON
+  -csv                  Output result as CSV
   -output prefix        Filename prefix for writing results to
 
 find options:

--- a/certipy/commands/parsers/find.py
+++ b/certipy/commands/parsers/find.py
@@ -43,6 +43,11 @@ def add_subparser(subparsers: argparse._SubParsersAction) -> Tuple[str, Callable
         help="Output result as JSON",
     )
     group.add_argument(
+        "-csv",
+        action="store_true",
+        help="Output result as CSV",
+    )
+    group.add_argument(
         "-output",
         action="store",
         metavar="prefix",


### PR DESCRIPTION
This PR is intened to add the option to export the extracted templates into a .csv format. This can be usefull if large CAs are examined and if audit reports want to provide actionable results to clients.