### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
         "dnspython",
         "dsinternals",
         "pyopenssl>=23.0.0",
-        "requests",
+        "requests<2.30.0",
         "requests_ntlm",
         'winacl; platform_system=="Windows"',
         'wmi; platform_system=="Windows"',


### PR DESCRIPTION
the latest version of requests(2.31.0) shipped with urllib3 2.0.4 leads to an error as follow when using -web options:

[!] Failed to connect to Web Enrollment interface: _http_request() got an unexpected keyword argument 'chunked'