### PR TITLE
Add whenCreated and whenModified to the output

### DIFF
--- a/certipy/commands/find.py
+++ b/certipy/commands/find.py
@@ -470,7 +470,7 @@ class Find:
 
             if self.json or not_specified:
                 with open("%s_Certipy.json" % prefix, "w") as f:
-                    json.dump(output, f, indent=2)
+                    json.dump(output, f, indent=2, default=str)
 
                 logging.info(
                     "Saved JSON output to %s" % repr("%s_Certipy.json" % prefix)
@@ -635,6 +635,7 @@ class Find:
                         },
                     },
                     f,
+                    default=str,
                 )
             zipf.write(gpos_filename, gpos_filename)
             os.unlink(gpos_filename)
@@ -667,6 +668,7 @@ class Find:
                         },
                     },
                     f,
+                    default=str,
                 )
             zipf.write(templates_filename, templates_filename)
             os.unlink(templates_filename)
@@ -736,6 +738,8 @@ class Find:
                 "pKIExtendedKeyUsage",
                 "nTSecurityDescriptor",
                 "objectGUID",
+                "whenCreated",
+                "whenChanged",
             ],
             query_sd=True,
         )
@@ -830,7 +834,9 @@ class Find:
             "authorized_signatures_required": "Authorized Signatures Required",
             "validity_period": "Validity Period",
             "renewal_period": "Renewal Period",
-            "msPKI-Minimal-Key-Size": "Minimum RSA Key Length"
+            "msPKI-Minimal-Key-Size": "Minimum RSA Key Length",
+            "whenCreated": "Template Created",
+            "whenChanged": "Template Last Modified",
         }
 
         if template_properties is None:

--- a/certipy/lib/formatting.py
+++ b/certipy/lib/formatting.py
@@ -1,4 +1,5 @@
 from typing import Callable, List, Tuple
+import datetime
 
 from certipy.lib.logger import logging
 
@@ -7,7 +8,6 @@ def to_pascal_case(snake_str: str) -> str:
     components = snake_str.split("_")
     return "".join(x.title() for x in components)
 
-
 def pretty_print(
     d: dict, indent: int = 0, padding: int = 40, print: Callable = print
 ) -> None:
@@ -15,6 +15,8 @@ def pretty_print(
         for key, value in d.items():
             if isinstance(value, str) or isinstance(value, int):
                 print(("  " * indent + str(key)).ljust(padding, " ") + ": %s" % value)
+            elif isinstance(value, datetime.datetime):
+                print(("  " * indent + str(key)).ljust(padding, " ") + ": %s" % value.isoformat())
             elif isinstance(value, dict):
                 print("  " * indent + str(key))
                 pretty_print(value, indent=indent + 1, print=print)


### PR DESCRIPTION
This pull request adds whenCreated and whenModified from the template LDAP properties, and properly handles the datetime format for the output. This can be useful for inferring how long an organization has been vulnerable to a particular exploit scenario. 