### PR TITLE
Fixing shadow.py to add more than 1 KeyCredential object and correctly list them

### DIFF
--- a/certipy/commands/shadow.py
+++ b/certipy/commands/shadow.py
@@ -53,6 +53,7 @@ class Shadow:
         results = self.connection.search(
             search_base=target_dn,
             search_filter="(objectClass=*)",
+            search_scope = ldap3.BASE,
             attributes=["SAMAccountName", "objectSid", "msDS-KeyCredentialLink"],
         )
 


### PR DESCRIPTION
As per title, this PR makes allows to set multiple KeyCredential objects for the same account (certipy currently overwrites the existing one) and allows properly listing them (which seemed to be faulty before).

Before:
![immagine](https://github.com/ly4k/Certipy/assets/73939366/a5a60f81-3782-4fcf-9175-7d2be6488b84)

Powerview.py can successfully read them:
![immagine](https://github.com/ly4k/Certipy/assets/73939366/8fab9211-7967-43ed-9d37-1889dcd7cd7a)

After:
![immagine](https://github.com/ly4k/Certipy/assets/73939366/e150e698-67fd-4aca-8d1a-da31963b5408)

This can be very useful when performing abusing GenericWrite/All privileges against an object that has the msDS-KeyCredentialLink already populated as it prevents attribute overwrites and then allows retrieving the device-id for easy removal.
