### PR TITLE
Add DCOM support for req command

### DIFF
--- a/certipy/commands/parsers/req.py
+++ b/certipy/commands/parsers/req.py
@@ -81,6 +81,11 @@ def add_subparser(subparsers: argparse._SubParsersAction) -> Tuple[str, Callable
         action="store_true",
         help="Use Web Enrollment instead of RPC",
     )
+    connection_group.add_argument(
+        "-dcom",
+        action="store_true",
+        help="Use DCOM Enrollment instead of RPC",
+    )
 
     group = subparser.add_argument_group("rpc connection options")
     group.add_argument(


### PR DESCRIPTION
In the last few months, we encountered more and more ADCS instances that neither supported web enrollment, nor exposed the CertSvc via plain RPC. The output of `certipy req` looks like this in that case:

```
[+] Trying to resolve 'XYZ.ABC' at '...'
[+] Trying to resolve 'ABC' at '...'
[+] Generating RSA key
[*] Requesting certificate via RPC
[+] Trying to connect to endpoint: ncacn_np:...[\pipe\cert]
[!] Failed to connect to endpoint ncacn_np:...[\pipe\cert]: SMB SessionError: STATUS_OBJECT_NAME_NOT_FOUND(The object name is not found.)
[+] Trying to resolve dynamic endpoint '91AE6020-9E3C-11CF-8D7C-00AA00C091BE'
[+] Failed to resolve dynamic endpoint '91AE6020-9E3C-11CF-8D7C-00AA00C091BE'
[-] Failed to get dynamic TCP endpoint for CertSvc
[-] Got error: 'NoneType' object has no attribute 'request'
```

Still, the ADCS was full functional and native Windows tooling like `mmc` was capable of obtaining certificates. At this point we noticed that `mmc` does not rely on plain RPC, but DCOM for obtaining the certificate. The corresponding DCOM interface `ICertRequestD` is described in this [microsoft spec](https://winprotocoldoc.blob.core.windows.net/productionwindowsarchives/MS-WCCE/%5bMS-WCCE%5d.pdf).

And indeed adjusting certipy to use DCOM instead of plain RPC allowed us to obtain certificates again. This MR adds this functionality and allows users to specify the `-dcom` switch with the `req` action.

The error handling was copied from the RPC related certipy code and may not fit 100% for COM. However, this is something that probably pops up in user issues and can be investigated then :upside_down_face: 

