### PR TITLE
accept tgs other than host/taget_name@domain

### DIFF
--- a/certipy/lib/kerberos.py
+++ b/certipy/lib/kerberos.py
@@ -80,7 +80,7 @@ def get_TGS(
 
             logging.debug("Using Kerberos Cache: %s" % os.getenv("KRB5CCNAME"))
             principal = "%s/%s@%s" % (service, target_name.upper(), domain.upper())
-            creds = ccache.getCredential(principal, anySPN=False)
+            creds = ccache.getCredential(principal)
             if creds is None:
                 # Let's try for the TGT and go from there
                 principal = "krbtgt/%s@%s" % (domain.upper(), domain.upper())


### PR DESCRIPTION
Currently if you want to use a TGS with certipy it has to be with the service class HOST in the service principal name of the TGS because `anySPN` is set to false in `getCredentials`. 
But I had a scenario with a LDAP service class in my TGS and couldn't use it without modifying the code.

With this PR removing the `anySPN=false` will allow `getCredentials` to retrieve any TGS matching the target_name@domain pattern in the cache list.

Knowing the service principal name doesn't matter as long as the TGS point out to the same host it will increase certipy flexibility.
