### PR TITLE
Add options for cross domain authentication

### DIFF
--- a/certipy/commands/find.py
+++ b/certipy/commands/find.py
@@ -92,6 +92,8 @@ class Find:
         enabled: bool = False,
         vulnerable: bool = False,
         hide_admins: bool = False,
+        sid: str = None,
+        dn: str = None,
         dc_only: bool = False,
         scheme: str = "ldaps",
         connection: LDAPConnection = None,
@@ -108,6 +110,8 @@ class Find:
         self.enabled = enabled
         self.vuln = vulnerable
         self.hide_admins = hide_admins
+        self.sid = sid
+        self.dn = dn
         self.dc_only = dc_only
         self.scheme = scheme
         self.verbose = debug
@@ -165,7 +169,7 @@ class Find:
         connection = self.connection
 
         if self.vuln:
-            sids = connection.get_user_sids(self.target.username)
+            sids = connection.get_user_sids(self.target.username, self.sid, self.dn)
 
             if self.verbose:
                 logging.debug("List of current user's SIDs:")
@@ -971,7 +975,7 @@ class Find:
         security = CertifcateSecurity(template.get("nTSecurityDescriptor"))
         owner_sid = security.owner
 
-        if owner_sid in self.connection.get_user_sids(self.target.username):
+        if owner_sid in self.connection.get_user_sids(self.target.username, self.sid, self.dn):
             vulnerabilities[
                 "ESC4"
             ] = "Template is owned by %s" % self.connection.lookup_sid(owner_sid).get(
@@ -996,7 +1000,7 @@ class Find:
         aces = security.aces
         vulnerable_acl_sids = []
         for sid, rights in aces.items():
-            if sid not in self.connection.get_user_sids(self.target.username):
+            if sid not in self.connection.get_user_sids(self.target.username, self.sid, self.dn):
                 continue
 
             ad_rights = rights["rights"]
@@ -1021,7 +1025,7 @@ class Find:
         aces = security.aces
         enrollable_sids = []
         for sid, rights in aces.items():
-            if sid not in self.connection.get_user_sids(self.target.username):
+            if sid not in self.connection.get_user_sids(self.target.username, self.sid, self.dn):
                 continue
 
             if (
@@ -1154,7 +1158,7 @@ class Find:
 
         aces = security.aces
         for sid, rights in aces.items():
-            if sid not in self.connection.get_user_sids(self.target.username):
+            if sid not in self.connection.get_user_sids(self.target.username, self.sid, self.dn):
                 continue
 
             ad_rights = rights["rights"]

--- a/certipy/commands/parsers/find.py
+++ b/certipy/commands/parsers/find.py
@@ -70,6 +70,18 @@ def add_subparser(subparsers: argparse._SubParsersAction) -> Tuple[str, Callable
         action="store_true",
         help="Don't show administrator permissions for -text, -stdout, and -json. Does not affect BloodHound output",
     )
+    group.add_argument(
+        "-sid",
+        action="store",
+        metavar="object sid",
+        help="SID of the user provided in the command line, useful for cross domain authentication.",
+    )
+    group.add_argument(
+        "-dn",
+        action="store",
+        metavar="distinguished name",
+        help="Distinguished name of the user provided in the command line, useful for cross domain authentication",
+    )
 
     group = subparser.add_argument_group("connection options")
     group.add_argument(

--- a/certipy/lib/ldap.py
+++ b/certipy/lib/ldap.py
@@ -351,16 +351,24 @@ class LDAPConnection:
 
         return domain_sid
 
-    def get_user_sids(self, username: str):
+    def get_user_sids(self, username: str, user_sid: str = None, user_dn: str = None):
         sanitized_username = username.lower().strip()
         if sanitized_username in self._user_sids:
             return self._user_sids[sanitized_username]
 
         user = self.get_user(username)
+        if not user:
+            user = {"objectSid": user_sid, "distinguishedName": user_dn}
+            if not user_sid:
+                logging.warning(
+                    "User SID can't be retrieved, for more accurate results, add it manually with -sid"
+                )
 
         sids = set()
-
-        sids.add(user.get("objectSid"))
+        
+        object_sid = user.get("objectSid")
+        if object_sid:
+            sids.add(object_sid)
 
         # Everyone, Authenticated Users, Users
         sids |= set(["S-1-1-0", "S-1-5-11", "S-1-5-32-545"])


### PR DESCRIPTION
If you attempt to authenticate on the domain with a user from a trusted domain you'll have the following error:
```ps1
silverVM:certipy$ python entry.py find -u robert@child.bloody.lab -p 'Password123!' -dc-ip 192.168.100.1 -debug -stdout
Certipy v4.8.2 - by Oliver Lyak (ly4k)

[+] Authenticating to LDAP server
[+] Bound to ldaps://192.168.100.1:636 - ssl
[+] Default path: DC=bloody,DC=lab
[+] Configuration path: CN=Configuration,DC=bloody,DC=lab
[*] Finding certificate templates
[*] Found 33 certificate templates
[*] Finding certificate authorities
[*] Found 1 certificate authority
[*] Found 11 enabled certificate templates
[+] Trying to resolve 'ALLMIGHTY.bloody.lab' at '192.168.100.1'
[*] Trying to get CA configuration for 'bloody-ALLMIGHTY-CA-1' via CSRA
[+] Trying to get DCOM connection for: 192.168.100.1
[!] Got error while trying to get CA configuration for 'bloody-ALLMIGHTY-CA-1' via CSRA: CASessionError: code: 0x80070005 - E_ACCESSDENIED - General access denied error.
[*] Trying to get CA configuration for 'bloody-ALLMIGHTY-CA-1' via RRP
[!] Failed to connect to remote registry. Service should be starting now. Trying again...
[+] Connected to remote registry at 'ALLMIGHTY.bloody.lab' (192.168.100.1)
[*] Got CA configuration for 'bloody-ALLMIGHTY-CA-1'
[+] Resolved 'ALLMIGHTY.bloody.lab' from cache: 192.168.100.1
[+] Connecting to 192.168.100.1:80
[-] Could not find user 'ROBERT'
[-] Got error: 'NoneType' object has no attribute 'get'
Traceback (most recent call last):
  File "/home/silver/git/Certipy/certipy/entry.py", line 60, in main
    actions[options.action](options)
  File "/home/silver/.local/lib/python3.11/site-packages/certipy/commands/parsers/find.py", line 12, in entry
    find.entry(options)
  File "/home/silver/.local/lib/python3.11/site-packages/certipy/commands/find.py", line 1179, in entry
    find.find()
  File "/home/silver/.local/lib/python3.11/site-packages/certipy/commands/find.py", line 458, in find
    output = self.get_output_for_text_and_json(templates, cas)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/silver/.local/lib/python3.11/site-packages/certipy/commands/find.py", line 489, in get_output_for_text_and_json
    vulnerabilities = self.get_template_vulnerabilities(template)
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/silver/.local/lib/python3.11/site-packages/certipy/commands/find.py", line 931, in get_template_vulnerabilities
    user_can_enroll, enrollable_sids = self.can_user_enroll_in_template(template)
                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/silver/.local/lib/python3.11/site-packages/certipy/commands/find.py", line 1024, in can_user_enroll_in_template
    if sid not in self.connection.get_user_sids(self.target.username):
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/silver/.local/lib/python3.11/site-packages/certipy/lib/ldap.py", line 363, in get_user_sids
    sids.add(user.get("objectSid"))
             ^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'get'
```

With this PR the execution flow will continue even if you can't retrieve the user LDAP information. You'll also be able to provide manually external SID and DN with the `-sid` and `-dn` options for the `find` functionality for the tool to find vulnerable certificates for your user:

```ps1
# Only SID provided
python certipy.py find -u robert@child.bloody.lab -p 'Password123!' -dc-ip 192.168.100.1 -debug -stdout -vulnerable -sid S-1-5-21-4050897367-477703294-3985875104-1102 
Certipy v4.8.2 - by Oliver Lyak (ly4k)

[+] Authenticating to LDAP server
[+] Bound to ldaps://192.168.100.1:636 - ssl
[+] Default path: DC=bloody,DC=lab
[+] Configuration path: CN=Configuration,DC=bloody,DC=lab
[-] Could not find user 'ROBERT'
[+] Adding Domain Computers to list of current user's SIDs
[!] Failed to lookup user with SID 'S-1-5-21-4050897367-477703294-3985875104-1102'
[+] List of current user's SIDs:
     S-1-5-21-4050897367-477703294-3985875104-1102 (S-1-5-21-4050897367-477703294-3985875104-1102)
     BLOODY.LAB\Everyone (BLOODY.LAB-S-1-1-0)
     BLOODY.LAB\Authenticated Users (BLOODY.LAB-S-1-5-11)
     BLOODY.LAB\Domain Computers (S-1-5-21-4024795361-627579832-1651831074-515)
     BLOODY.LAB\Users (BLOODY.LAB-S-1-5-32-545)

# DN and SID provided 
python certipy.py find -u robert@child.bloody.lab -p 'Password123!' -dc-ip 192.168.100.1 -debug -stdout -vulnerable -sid S-1-5-21-4050897367-477703294-3985875104-1102 -dn CN=robet,CN=Users,DC=child,DC=bloody,DC=lab
Certipy v4.8.2 - by Oliver Lyak (ly4k)

[+] Authenticating to LDAP server
[+] Bound to ldaps://192.168.100.1:636 - ssl
[+] Default path: DC=bloody,DC=lab
[+] Configuration path: CN=Configuration,DC=bloody,DC=lab
[-] Could not find user 'ROBERT'
[+] Adding Domain Computers to list of current user's SIDs
[!] Failed to lookup user with SID 'S-1-5-21-4050897367-477703294-3985875104-1102'
[+] List of current user's SIDs:
     BLOODY.LAB\Print Operators (BLOODY.LAB-S-1-5-32-550)
     BLOODY.LAB\Users (BLOODY.LAB-S-1-5-32-545)
     BLOODY.LAB\Everyone (BLOODY.LAB-S-1-1-0)
     S-1-5-21-4050897367-477703294-3985875104-1102 (S-1-5-21-4050897367-477703294-3985875104-1102)
     BLOODY.LAB\Domain Computers (S-1-5-21-4024795361-627579832-1651831074-515)
     BLOODY.LAB\Authenticated Users (BLOODY.LAB-S-1-5-11)

# No SID/DN provided
    python certipy.py find -u robert@child.bloody.lab -p 'Password123!' -dc-ip 192.168.100.1 -debug -stdout -vulnerable
Certipy v4.8.2 - by Oliver Lyak (ly4k)

[+] Authenticating to LDAP server
[+] Bound to ldaps://192.168.100.1:636 - ssl
[+] Default path: DC=bloody,DC=lab
[+] Configuration path: CN=Configuration,DC=bloody,DC=lab
[-] Could not find user 'ROBERT'
[!] User SID can't be retrieved, for more accurate results, add it manually with -sid
[+] Adding Domain Computers to list of current user's SIDs
[+] List of current user's SIDs:
     BLOODY.LAB\Everyone (BLOODY.LAB-S-1-1-0)
     BLOODY.LAB\Users (BLOODY.LAB-S-1-5-32-545)
     BLOODY.LAB\Authenticated Users (BLOODY.LAB-S-1-5-11)
     BLOODY.LAB\Domain Computers (S-1-5-21-4024795361-627579832-1651831074-515)
```