### PR TITLE
Add switch for SMIME Extensions support

### DIFF
--- a/certipy/commands/parsers/req.py
+++ b/certipy/commands/parsers/req.py
@@ -71,7 +71,11 @@ def add_subparser(subparsers: argparse._SubParsersAction) -> Tuple[str, Callable
         action="store_true",
         help="Create renewal request",
     )
-
+    group.add_argument(
+        "-smime",
+        action="store",
+        help="Specify SMIME Extension that gets added to CSR eg: des, rc4, 3des, aes128, aes192, aes256",
+    )
     group = subparser.add_argument_group("output options")
     group.add_argument("-out", action="store", metavar="output file name")
 

--- a/certipy/commands/req.py
+++ b/certipy/commands/req.py
@@ -539,6 +539,7 @@ class Request:
         scheme: str = None,
         dynamic_endpoint: bool = False,
         debug=False,
+        smime: str = None,
         **kwargs
     ):
         self.target = target
@@ -556,6 +557,7 @@ class Request:
         self.renew = renew
         self.out = out
         self.key = key
+        self.smime = smime
 
         self.web = web
         self.port = port
@@ -676,6 +678,7 @@ class Request:
             key_size=self.key_size,
             subject=self.subject,
             renewal_cert=renewal_cert,
+            smime=self.smime,
         )
         self.key = key
 

--- a/certipy/lib/certificate.py
+++ b/certipy/lib/certificate.py
@@ -53,12 +53,14 @@ DN_MAP = {
 asn1x509.ExtensionId._map.update(
     {
         "1.3.6.1.4.1.311.25.2": "security_ext",
+        "1.2.840.113549.1.9.15": "smime_capability",
     }
 )
 
 asn1x509.Extension._oid_specs.update(
     {
         "security_ext": asn1x509.GeneralNames,
+        "smime_capability": asn1core.ObjectIdentifier,
     }
 )
 
@@ -73,6 +75,16 @@ szOID_ENCRYPTED_KEY_HASH = asn1cms.ObjectIdentifier("1.3.6.1.4.1.311.21.21")
 szOID_CMC_ADD_ATTRIBUTES = asn1cms.ObjectIdentifier("1.3.6.1.4.1.311.10.10.1")
 szOID_NTDS_CA_SECURITY_EXT = asn1cms.ObjectIdentifier("1.3.6.1.4.1.311.25.2")
 szOID_NTDS_OBJECTSID = asn1cms.ObjectIdentifier("1.3.6.1.4.1.311.25.2.1")
+
+# https://learn.microsoft.com/en-us/windows/win32/api/certenroll/nn-certenroll-ix509extensionsmimecapabilities
+smimedict = {
+    "des":"1.3.14.3.2.7",
+    "rc4":"1.2.840.113549.3.4",
+    "3des":"1.2.840.113549.1.9.16.3.6",
+    "aes128":"2.16.840.1.101.3.4.1.5",
+    "aes192":"2.16.840.1.101.3.4.1.25",
+    "aes256":"2.16.840.1.101.3.4.1.45",
+}
 
 class TaggedCertificationRequest(asn1core.Sequence):
     _fields = [
@@ -334,6 +346,7 @@ def create_csr(
     key_size: int = 2048,
     subject: str = None,
     renewal_cert: x509.Certificate = None,
+    smime: str = None,
 ) -> Tuple[x509.CertificateSigningRequest, rsa.RSAPrivateKey]:
     if key is None:
         logging.debug("Generating RSA key")
@@ -397,6 +410,20 @@ def create_csr(
         )
 
         set_of_extensions = asn1csr.SetOfExtensions([[san_extension]])
+
+        cri_attribute = asn1csr.CRIAttribute(
+            {"type": "extension_request", "values": set_of_extensions}
+        )
+
+        cri_attributes.append(cri_attribute)
+
+    if smime:
+        # https://learn.microsoft.com/en-us/windows/win32/api/certenroll/nn-certenroll-ix509extensionsmimecapabilities
+        smime_extension = asn1x509.Extension(
+                {"extn_id": "1.2.840.113549.1.9.15", "extn_value": smimedict[smime]}
+        )
+
+        set_of_extensions = asn1csr.SetOfExtensions([[smime_extension]])
 
         cri_attribute = asn1csr.CRIAttribute(
             {"type": "extension_request", "values": set_of_extensions}

--- a/certipy/lib/certificate.py
+++ b/certipy/lib/certificate.py
@@ -53,14 +53,12 @@ DN_MAP = {
 asn1x509.ExtensionId._map.update(
     {
         "1.3.6.1.4.1.311.25.2": "security_ext",
-        "1.2.840.113549.1.9.15": "smime_capability",
     }
 )
 
 asn1x509.Extension._oid_specs.update(
     {
         "security_ext": asn1x509.GeneralNames,
-        "smime_capability": asn1core.ObjectIdentifier,
     }
 )
 
@@ -418,6 +416,17 @@ def create_csr(
         cri_attributes.append(cri_attribute)
 
     if smime:
+        asn1x509.ExtensionId._map.update(
+            {
+                "1.2.840.113549.1.9.15": "smime_capability",
+            }
+        )
+        
+        asn1x509.Extension._oid_specs.update(
+            {
+                "smime_capability": asn1core.ObjectIdentifier,
+            }
+        ) 
         # https://learn.microsoft.com/en-us/windows/win32/api/certenroll/nn-certenroll-ix509extensionsmimecapabilities
         smime_extension = asn1x509.Extension(
                 {"extn_id": "1.2.840.113549.1.9.15", "extn_value": smimedict[smime]}


### PR DESCRIPTION
Adds a switch to include SMIME Capabilitie Extensions into the CSR.
In some scenarios these extensions are mandatory to request a certificate. If there is no SMIME Extension in the CSR certipy is not able to request a certificate:

```bash
$ certipy req -dc-ip 192.0.2.1 -u user1@lab.domain -p 'Pass123!' -template User -ca 'Test-CA'
Certipy v4.8.2 - by Oliver Lyak (ly4k)

[*] Requesting certificate via RPC
[-] Got error while trying to request certificate: code: 0x80094805 - CERTSRV_E_SMIME_REQUIRED - The request is missing a required SMIME capabilities extension.
[*] Request ID is 23
Would you like to save the private key? (y/N) 
```
Including the extensions results in a usable certificate:

```bash
$ certipy req -dc-ip 192.0.2.1 -u user1@lab.domain -p 'Pass123!' -template User -ca 'Test-CA' -smime des
Certipy v4.8.2 - by Oliver Lyak (ly4k)

[*] Requesting certificate via RPC
[*] Successfully requested certificate
[*] Request ID is 24
[*] Got certificate with UPN 'user1@lab.domain'
[*] Certificate object SID is 'S-1-5-21-4020831100-2203696187-1704472354-1106'
[*] Saved certificate and private key to 'user1.pfx'
```

In our testing it did not matter which SMIME capabilities got used as long as they were not empty.

