### PR TITLE
add ldap simple auth

### DIFF
--- a/certipy/commands/parsers/target.py
+++ b/certipy/commands/parsers/target.py
@@ -104,3 +104,8 @@ def add_argument_group(
         action="store_true",
         help="Use LDAP channel binding for LDAP communication (LDAPS only)",
     )
+    group.add_argument(
+        "-ldap-auth-simple",
+        action="store_true",
+        help="Use ldap3.SIMPLE auth type"
+    )

--- a/certipy/lib/target.py
+++ b/certipy/lib/target.py
@@ -1,10 +1,12 @@
 import os
 import platform
 import socket
+from typing import Literal
 
-from certipy.lib.logger import logging
 from dns.resolver import Resolver
 from impacket.krb5.ccache import CCache
+
+from certipy.lib.logger import logging
 
 
 def is_ip(hostname: str) -> bool:
@@ -106,8 +108,9 @@ def get_logon_session():
     if platform.system().lower() != "windows":
         raise Exception("Cannot use SSPI on non-Windows platform")
 
-    from certipy.lib.sspi import get_tgt
     from winacl.functions.highlevel import get_logon_info
+
+    from certipy.lib.sspi import get_tgt
 
     info = get_logon_info()
 
@@ -159,12 +162,15 @@ class Target:
         self.timeout: int = 5
         self.resolver: Resolver = None
         self.ldap_channel_binding = None
+        self.auth_type: Literal['ntlm', 'simple'] = None
 
     @staticmethod
     def from_options(
         options, dc_as_target: bool = False, ptt: bool = False
     ) -> "Target":
         self = Target()
+
+        self.auth_type = 'simple' if options.ldap_auth_simple else 'ntlm'
 
         principal = options.username
         domain = ""


### PR DESCRIPTION
Introduces a new option `-ldap-simple-auth` to enable LDAP simple authentication using `ldap3.SIMPLE`. This provides an alternative to the existing `ldap3.NTLM` authentication method.

This allows users to authenticate using LDAP simple authentication, which may be required in environments where NTLM is not supported or desired.