### PR TITLE
[FIX] Check pKIExpirationPeriod & pKIOverlapPeriod

### DIFF
--- a/certipy/commands/find.py
+++ b/certipy/commands/find.py
@@ -330,10 +330,18 @@ class Find:
             object_id = template.get("objectGUID").lstrip("{").rstrip("}")
             template.set("object_id", object_id)
 
-            validity_period = filetime_to_str(template.get("pKIExpirationPeriod"))
+            expiration_period = template.get("pKIExpirationPeriod")
+            if expiration_period is not None:
+                validity_period = filetime_to_str(expiration_period)
+            else:
+                validity_period = 0
             template.set("validity_period", validity_period)
 
-            renewal_period = filetime_to_str(template.get("pKIOverlapPeriod"))
+            overlap_period = template.get("pKIOverlapPeriod")
+            if overlap_period is not None:
+                renewal_period = filetime_to_str(overlap_period)
+            else:
+                renewal_period = 0
             template.set("renewal_period", renewal_period)
 
             certificate_name_flag = template.get("msPKI-Certificate-Name-Flag")


### PR DESCRIPTION
It's possible with the following script to generate a Template Certificate without pKIExpirationPeriod & pKIOverlapPeriod properties.

```ps1
$ADSI = [ADSI]"LDAP://CN=Certificate Templates,CN=Public Key Services,CN=Services,$((Get-ADRootDSE).namingContexts[1])"
$pki = $ADSI.Create("pKICertificateTemplate", "CN=pKIExpirationPeriod ")
$pki.put("msPKI-Certificate-Name-Flag", 1)
$pki.put("pKIExtendedKeyUsage", @("1.3.6.1.5.5.7.3.2"))
$pki.setInfo()
```

![pKIExpirationPeriod](https://github.com/user-attachments/assets/f8e2d8c3-ae7b-4b47-8c36-d7dbb667865e)

In this case, certipy will crash :

![certipy](https://github.com/user-attachments/assets/6b272fe4-daab-46b0-9feb-29653986360f)

If you try to do the same thing with the GUI, this will not work :

![Protection](https://github.com/user-attachments/assets/3ff82287-c1d4-46d0-8aa3-d075bd59631b)

This PR aims to check the value of these two properties and set it to zero if there are not found.