### PR TITLE
Add password parameter to auth command

### DIFF
--- a/certipy/commands/auth.py
+++ b/certipy/commands/auth.py
@@ -106,6 +106,7 @@ class Authenticate:
         self,
         target: Target = None,
         pfx: str = None,
+        password: str = None,
         cert: x509.Certificate = None,
         key: rsa.RSAPublicKey = None,
         no_save: bool = False,
@@ -123,6 +124,7 @@ class Authenticate:
     ):
         self.target = target
         self.pfx = pfx
+        self.password = password
         self.cert = cert
         self.key = key
         self.no_save = no_save
@@ -144,8 +146,13 @@ class Authenticate:
         self.lm_hash: str = None
 
         if self.pfx is not None:
+            password = None
+            if self.password:
+                password = self.password.encode()
             with open(self.pfx, "rb") as f:
-                self.key, self.cert = load_pfx(f.read())
+                pfx = f.read()
+            self.key, self.cert = load_pfx(pfx, password)
+
 
     def authenticate(
         self, username: str = None, domain: str = None, is_key_credential=False

--- a/certipy/commands/parsers/auth.py
+++ b/certipy/commands/parsers/auth.py
@@ -24,6 +24,10 @@ def add_subparser(subparsers: argparse._SubParsersAction) -> Tuple[str, Callable
     )
 
     subparser.add_argument(
+        "-password", action="store", metavar="password", help="Set import password"
+    )
+
+    subparser.add_argument(
         "-no-save", action="store_true", help="Don't save TGT to file"
     )
     subparser.add_argument(


### PR DESCRIPTION
When using an encrypted PFX for authentication, I find it useful to provide the tool with the password directly, rather than decrypting it on disk first and then using it for authentication.

```sh
certipy auth -pfx "./cert.pfx" -password 'P4ssw0rd' -dc-ip 192.168.1.1 -username 'COMPUTER$' -domain hackn.lab
```