### PR TITLE
Add parse sub command to perform stealthy offline AD CS enumeration based on local registry data

### DIFF
--- a/certipy/commands/find.py
+++ b/certipy/commands/find.py
@@ -307,20 +307,24 @@ class Find:
 
             subject_name = ca.get("cACertificateDN")
 
-            ca_cert = x509.Certificate.load(ca.get("cACertificate")[0])[
-                "tbs_certificate"
-            ]
+            try:
+                ca_cert = x509.Certificate.load(ca.get("cACertificate")[0])[
+                    "tbs_certificate"
+                ]
 
-            serial_number = hex(int(ca_cert["serial_number"]))[2:].upper()
+                serial_number = hex(int(ca_cert["serial_number"]))[2:].upper()
 
-            validity = ca_cert["validity"].native
-            validity_start = str(validity["not_before"])
-            validity_end = str(validity["not_after"])
+                validity = ca_cert["validity"].native
+                validity_start = str(validity["not_before"])
+                validity_end = str(validity["not_after"])
 
-            ca.set("subject_name", subject_name)
-            ca.set("serial_number", serial_number)
-            ca.set("validity_start", validity_start)
-            ca.set("validity_end", validity_end)
+                ca.set("subject_name", subject_name)
+                ca.set("serial_number", serial_number)
+                ca.set("validity_start", validity_start)
+                ca.set("validity_end", validity_end)
+            except ValueError:
+                logging.warning("Could not parse CA certificate")
+                pass
 
         for template in templates:
             template_cas = template.get("cas")

--- a/certipy/commands/parse.py
+++ b/certipy/commands/parse.py
@@ -1,0 +1,157 @@
+import argparse
+import re
+
+from typing import List
+from certipy.lib.registry import RegConnection, RegEntry
+from certipy.commands import find
+
+class Parse(find.Find):
+    def __init__(
+        self,
+        domain: str = "UNKNOWN",
+        sids: List[str] = [],
+        published: List[str] = [],
+        **kwargs
+    ):
+        super().__init__(self, **kwargs)
+        self.dc_only = True
+        self.target.username = 'unknown'
+        self.target.target_ip = 'unknown'
+        self.domain = domain
+        self.sids = sids
+        self.published = published
+        self.mappings = {
+            # "KeyUsage" : "TODO"
+            "DisplayName": "displayName",
+            "ValidityPeriod": "pKIExpirationPeriod",
+            "RenewalOverlap": "pKIOverlapPeriod",
+            "ExtKeyUsageSyntax": "pKIExtendedKeyUsage",
+            "Security": "nTSecurityDescriptor",
+        }
+
+    @property
+    def connection(self) -> RegConnection:
+        if self._connection is not None:
+            return self._connection
+
+        self._connection = RegConnection(self.domain, self.sids)
+        return self._connection
+
+    def get_issuance_policies(self) -> List[RegEntry]:
+        return []
+
+    def get_certificate_authorities(self) -> List[RegEntry]:
+        if len(self.published) == 0:
+            return []
+
+        ca = RegEntry(
+            **{
+                "attributes": {
+                    "cn" : "Unknown",
+                    "name" : "Unknown",
+                    "dNSHostName" : "localhost",
+                    "cACertificateDN" : "Unknown",
+                    "cACertificate" : [ b"" ],
+                    "certificateTemplates" : self.published,
+                    "objectGUID": "Unknown",
+                }
+            }
+        )
+
+        return [ca]
+
+    def parse(self, file: str):
+        self.file = file
+        return self.find()
+
+class ParseBof(Parse):
+
+    def get_certificate_templates(self) -> List[RegEntry]:
+
+        templates = []
+
+        with open(self.file, "r", encoding="utf-8") as f:
+            contents = f.read()
+            data = re.sub(r'\n\n\d{2}\/\d{2} (\d{2}:){2}\d{2} UTC \[output\]\nreceived output:\n', '', contents)
+            lines = iter(data.splitlines())
+            line = next(lines)
+
+            template = None
+
+            while True:
+                try:
+                    datatype = None
+
+                    if 'HKEY_USERS\.DEFAULT\\Software\\Microsoft\\Cryptography\\CertificateTemplateCache\\' in line:
+                        if template is not None:
+                            templates.append(template)
+                            # print(template)
+                        template = RegEntry()
+                        parts = line.split('\\')
+                        template.set("cn", parts[-1])
+                        template.set("name", parts[-1])
+                        template.set("objectGUID", parts[-1])
+                        line = next(lines)
+                        continue
+
+                    if line.startswith('\t'):
+                        line = line.strip()
+                        parts = re.split('\s+', line)
+                        if len(parts) < 2:
+                            line = next(lines)
+                            continue
+                        name = parts[0]
+                        datatype = parts[1]
+                        data = parts[2] if len(parts) > 2 else None
+                        if datatype == 'REG_DWORD':
+                            data = int(line.split('REG_DWORD')[1].strip())
+                        elif datatype == 'REG_SZ':
+                            data = line.split('REG_SZ')[1].strip()
+                        elif datatype == 'REG_MULTI_SZ':
+                            data = line.split('REG_MULTI_SZ')[1].strip()
+                            if data == '':
+                                data = []
+                            else:
+                                data = data.split("\\0")
+                        elif datatype == 'REG_BINARY':
+                            data = []
+                            while True:
+                                line = next(lines)
+                                if not line.startswith(" "):
+                                    break
+                                else:
+                                    data = data + re.split("\s+", line.strip())
+                            # print(data)
+                            data = bytes.fromhex("".join(data))
+
+                        if name in self.mappings:
+                            name = self.mappings[name]
+                        if not template is None:
+                            template.set(name, data)
+
+                    if datatype != 'REG_BINARY':
+                        line = next(lines)
+                except StopIteration:
+                    break
+
+            if template is not None:
+                templates.append(template)
+
+        return templates
+
+def entry(options: argparse.Namespace) -> None:
+
+    domain = options.domain
+    del options.domain
+
+    sids = options.sids
+    del options.sids
+
+    published = options.published
+    del options.published
+
+    file = options.file
+    del options.file
+
+    parse = ParseBof(domain, sids, published, **vars(options))
+    parse.parse(file)

--- a/certipy/commands/parse.py
+++ b/certipy/commands/parse.py
@@ -9,6 +9,7 @@ class Parse(find.Find):
     def __init__(
         self,
         domain: str = "UNKNOWN",
+        ca: str = "UNKNOWN",
         sids: List[str] = [],
         published: List[str] = [],
         **kwargs
@@ -18,6 +19,7 @@ class Parse(find.Find):
         self.target.username = 'unknown'
         self.target.target_ip = 'unknown'
         self.domain = domain
+        self.ca = ca
         self.sids = sids
         self.published = published
         self.mappings = {
@@ -48,7 +50,7 @@ class Parse(find.Find):
             **{
                 "attributes": {
                     "cn" : "Unknown",
-                    "name" : "Unknown",
+                    "name" : self.ca,
                     "dNSHostName" : "localhost",
                     "cACertificateDN" : "Unknown",
                     "cACertificate" : [ b"" ],
@@ -231,6 +233,9 @@ def entry(options: argparse.Namespace) -> None:
     domain = options.domain
     del options.domain
 
+    ca = options.ca
+    del options.ca
+
     sids = options.sids
     del options.sids
 
@@ -244,8 +249,8 @@ def entry(options: argparse.Namespace) -> None:
     del options.format
 
     if format == 'bof':
-        parse = ParseBof(domain, sids, published, **vars(options))
+        parse = ParseBof(domain, ca, sids, published, **vars(options))
     if format == 'reg':
-        parse = ParseReg(domain, sids, published, **vars(options))
+        parse = ParseReg(domain, ca, sids, published, **vars(options))
 
     parse.parse(file)

--- a/certipy/commands/parsers/__init__.py
+++ b/certipy/commands/parsers/__init__.py
@@ -1,4 +1,4 @@
-from . import account, auth, ca, cert, find, forge, ptt, relay, req, shadow, template
+from . import account, auth, ca, cert, find, parse, forge, ptt, relay, req, shadow, template
 
 ENTRY_PARSERS = [
     account,
@@ -6,6 +6,7 @@ ENTRY_PARSERS = [
     ca,
     cert,
     find,
+    parse,
     forge,
     ptt,
     relay,

--- a/certipy/commands/parsers/parse.py
+++ b/certipy/commands/parsers/parse.py
@@ -1,0 +1,85 @@
+NAME = "parse"
+
+import argparse
+from typing import Callable, Tuple
+
+def entry(options: argparse.Namespace):
+    from certipy.commands import parse
+
+    parse.entry(options)
+
+
+def add_subparser(subparsers: argparse._SubParsersAction) -> Tuple[str, Callable]:
+    subparser = subparsers.add_parser(NAME, help="Offline enumerate AD CS based on registry data")
+    subparser.add_argument("file", help="file to parse")
+    subparser.add_argument("-debug", action="store_true", help="Turn debug output on")
+
+    group = subparser.add_argument_group("output options")
+    group.add_argument(
+        "-bloodhound",
+        action="store_true",
+        help="Output result as BloodHound data for the custom-built BloodHound version from @ly4k with PKI support",
+    )
+    group.add_argument(
+        "-old-bloodhound",
+        action="store_true",
+        help="Output result as BloodHound data for the original BloodHound version from @BloodHoundAD without PKI support",
+    )
+    group.add_argument(
+        "-text",
+        action="store_true",
+        help="Output result as text",
+    )
+    group.add_argument(
+        "-stdout",
+        action="store_true",
+        help="Output result as text to stdout",
+    )
+    group.add_argument(
+        "-json",
+        action="store_true",
+        help="Output result as JSON",
+    )
+    group.add_argument(
+        "-output",
+        action="store",
+        metavar="prefix",
+        help="Filename prefix for writing results to",
+    )
+
+    group = subparser.add_argument_group("parse options")
+    group.add_argument(
+        "-domain",
+        help="Domain name, solely used for output (default: UNKNOWN)",
+        type=lambda arg: arg.upper(),
+        default="UNKNOWN"
+    )
+    group.add_argument(
+        "-sids",
+        help="Consider the comma separated list of SIDs as owned",
+        type=lambda arg: list(map(str.strip, arg.split(','))),
+        default=[]
+    )
+    group.add_argument(
+        "-published",
+        help="Consider the comma separated list of template names as published",
+        type=lambda arg: list(map(str.strip, arg.split(','))),
+        default=[]
+    )
+    group.add_argument(
+        "-enabled",
+        action="store_true",
+        help="Show only enabled certificate templates. Does not affect BloodHound output",
+    )
+    group.add_argument(
+        "-vulnerable",
+        action="store_true",
+        help="Show only vulnerable certificate templates based on nested group memberships. Does not affect BloodHound output",
+    )
+    group.add_argument(
+        "-hide-admins",
+        action="store_true",
+        help="Don't show administrator permissions for -text, -stdout, and -json. Does not affect BloodHound output",
+    )
+
+    return NAME, entry

--- a/certipy/commands/parsers/parse.py
+++ b/certipy/commands/parsers/parse.py
@@ -49,6 +49,12 @@ def add_subparser(subparsers: argparse._SubParsersAction) -> Tuple[str, Callable
 
     group = subparser.add_argument_group("parse options")
     group.add_argument(
+        "-format",
+        help="Input format either req_query BOF output or Windows .reg file (default: bof)",
+        choices=["bof", "reg"],
+        default="bof"
+    )
+    group.add_argument(
         "-domain",
         help="Domain name, solely used for output (default: UNKNOWN)",
         type=lambda arg: arg.upper(),

--- a/certipy/commands/parsers/parse.py
+++ b/certipy/commands/parsers/parse.py
@@ -61,6 +61,11 @@ def add_subparser(subparsers: argparse._SubParsersAction) -> Tuple[str, Callable
         default="UNKNOWN"
     )
     group.add_argument(
+        "-ca",
+        help="CA name, solely used for output (default: UNKNOWN)",
+        default="UNKNOWN"
+    )
+    group.add_argument(
         "-sids",
         help="Consider the comma separated list of SIDs as owned",
         type=lambda arg: list(map(str.strip, arg.split(','))),

--- a/certipy/lib/constants.py
+++ b/certipy/lib/constants.py
@@ -66,6 +66,27 @@ WELLKNOWN_SIDS = {
     "S-1-5-32-580": ("Access Control Assistance Operators", "GROUP"),
 }
 
+# https://github.com/garrettfoster13/aced/blob/b5d1ad1b8cfb84a6420be22658beec340ef9e396/lib/sid.py#L48
+WELLKNOWN_RIDS = {
+    "498": ("Enterprise Read-only Domain Controllers", "GROUP"),
+    "500": ("Administrator", "USER"),
+    "501": ("Guest", "USER"),
+    "502": ("KRBTGT", "USER"),
+    "512": ("Domain Admins", "GROUP"),
+    "513": ("Domain Users", "GROUP"),
+    "514": ("Domain Guests", "GROUP"),
+    "515": ("Domain Computers", "GROUP"),
+    "516": ("Domain Controllers", "GROUP"),
+    "517": ("Cert Publishers", "GROUP"),
+    "518": ("Schema Admins", "GROUP"),
+    "519": ("Enterprise Admins", "GROUP"),
+    "520": ("Group Policy Creator Owners", "GROUP"),
+    "521": ("Read-only Domain Controllers", "GROUP"),
+    "522": ("Cloneable Domain Controllers", "GROUP"),
+    "526": ("Key Admins", "GROUP"),
+    "527": ("Enterprise Key Admins", "GROUP"),
+    "553": ("RAS and IAS Servers", "GROUP"),
+}
 
 # https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-crtd/1192823c-d839-4bc3-9b6b-fa8c53507ae1
 class MS_PKI_CERTIFICATE_NAME_FLAG(IntFlag):

--- a/certipy/lib/registry.py
+++ b/certipy/lib/registry.py
@@ -1,0 +1,57 @@
+from typing import List
+from certipy.lib.constants import WELLKNOWN_SIDS
+from certipy.lib.ldap import LDAPEntry
+
+class RegEntry(LDAPEntry):
+
+    def __init__(self, **kwargs):
+        super().__init__(self, **kwargs)
+        if not 'attributes' in self:
+            self['attributes'] = {}
+
+    def get_raw(self, key):
+        data = self.get(key)
+        if isinstance(data, str):
+            return s.encode()
+        elif isinstance(data, list):
+            return list(map(lambda x: x.encode(), data))
+        return data
+
+class RegConnection():
+
+    def __init__(self, domain: str, sids: List[str], scheme: str = "file"):
+        self.domain = domain
+        self.sids = sids
+        self.sid_map = {}
+
+    def get_user_sids(self, username: str):
+        return self.sids
+
+    def lookup_sid(self, sid: str) -> RegEntry:
+        if sid in self.sid_map:
+            return self.sid_map[sid]
+
+        if sid in WELLKNOWN_SIDS:
+            return RegEntry(
+                **{
+                    "attributes": {
+	                    "objectSid": "%s-%s" % (self.domain.upper(), sid),
+	                    "objectType": WELLKNOWN_SIDS[sid][1].capitalize(),
+	                    "name": "%s\\%s" % (self.domain, WELLKNOWN_SIDS[sid][0]),
+                    }
+                }
+            )
+
+        entry = RegEntry(
+            **{
+                "attributes": {
+                    "objectSid": sid,
+                    "name": sid,
+                    "objectType": "Base",
+                }
+            }
+        )
+
+        self.sid_map[sid] = entry
+
+        return entry

--- a/certipy/lib/registry.py
+++ b/certipy/lib/registry.py
@@ -24,7 +24,7 @@ class RegConnection():
         self.sids = sids
         self.sid_map = {}
 
-    def get_user_sids(self, username: str):
+    def get_user_sids(self, username: str, user_sid: str = None, user_dn: str = None):
         return self.sids
 
     def lookup_sid(self, sid: str) -> RegEntry:

--- a/certipy/lib/registry.py
+++ b/certipy/lib/registry.py
@@ -1,5 +1,5 @@
 from typing import List
-from certipy.lib.constants import WELLKNOWN_SIDS
+from certipy.lib.constants import WELLKNOWN_SIDS, WELLKNOWN_RIDS
 from certipy.lib.ldap import LDAPEntry
 
 class RegEntry(LDAPEntry):
@@ -38,6 +38,18 @@ class RegConnection():
 	                    "objectSid": "%s-%s" % (self.domain.upper(), sid),
 	                    "objectType": WELLKNOWN_SIDS[sid][1].capitalize(),
 	                    "name": "%s\\%s" % (self.domain, WELLKNOWN_SIDS[sid][0]),
+                    }
+                }
+            )
+
+        rid = sid.split("-")[-1]
+        if rid in WELLKNOWN_RIDS:
+            return RegEntry(
+                **{
+                    "attributes": {
+	                    "objectSid": "%s-%s" % (self.domain.upper(), sid),
+	                    "objectType": WELLKNOWN_RIDS[rid][1].capitalize(),
+	                    "name": "%s\\%s" % (self.domain, WELLKNOWN_RIDS[rid][0]),
                     }
                 }
             )


### PR DESCRIPTION
This adds a new `certipy parse` sub command which can be used to offline parse the content of the local registry certificate template cache as captured by either TrustedSec's `req_query` BOF or a `.reg` export as produced by the native `regedit.exe` utility.

It is based on [The Registry Rundown](https://troopers.de/troopers24/talks/jlaupj/) research by Outflank's Cedric Van Bockhaven and Max Grim as presented at Troopers 24.

The implementation tries to minimize code duplication by implementing the existing LDAP interfaces using the data from the registry. As such modification to the generic vulnerability detection logic in `find.py` is mostly avoided.

The changes have been tested against [Ludus' AD CS role](https://docs.ludus.cloud/docs/environment-guides/adcs).

First a regular LDAP enumeration was performed with:
```
$ certipy find -u domainuser@ludus.domain -p password -dc-ip 10.5.10.11
```

This was then compared to the data obtained by parsing the output of:
```
beacon> reg_query_recursive HKU .DEFAULT\Software\Microsoft\Cryptography\CertificateTemplateCache
```

With a command like:
```
$ certipy parse -format bof -domain ludus.domain -ca ludus-CA -published "ESC13, ESC9, ESC7_CERTMGR, ESC4, ESC3_CRA, ESC3, ESC2, ESC1, DirectoryEmailReplication, DomainControllerAuthentication, KerberosAuthentication, EFSRecovery, EFS, DomainController, WebServer, Machine, User, SubCA, Administrator" -sids "S-1-5-21-3291837554-245906837-2404182060-513,S-1-5-21-3291837554-245906837-2404182060-1104" beacon.log
```

Where the published certificate templates were looked up with:
```
beacon> ldapsearch "(objectclass=pKIEnrollmentService)" --attributes certificateTemplates --dn "CN=Configuration,DC=ludus,DC=domain" --ldaps
```

Similarly, the corresponding registry branch was exported from a client machine using the native `regedit.exe` utility and subsequently parsed with:
```
$ certipy parse -format reg -domain ludus.domain -ca ludus-CA -published "ESC13, ESC9, ESC7_CERTMGR, ESC4, ESC3_CRA, ESC3, ESC2, ESC1, DirectoryEmailReplication, DomainControllerAuthentication, KerberosAuthentication, EFSRecovery, EFS, DomainController, WebServer, Machine, User, SubCA, Administrator" -sids "S-1-5-21-3291837554-245906837-2404182060-513,S-1-5-21-3291837554-245906837-2404182060-1104" adcs.reg
```

Results were compared with the data obtained via LDAP after normalizing the JSON output with:
```
$ jq '[ ."Certificate Templates"|values[] ] | sort_by(."Template Name")' < bof.json  > bof.json.sorted
```

The only observed differences concern some template metadata fields (creation/modification date) and a few settings related to issuance policies.

@zimedev the changes should also be compatible with your certipy-merged repository.