### PR TITLE
Adds support for ESC14

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Certipy is an offensive tool for enumerating and abusing Active Directory Certif
       - [ESC8](#esc8)
       - [ESC9 & ESC10](#esc9--esc10)
       - [ESC11](#esc11)
+      - [ESC14](#esc14)
   - [Contact](#contact)
   - [Credits](#credits)
 
@@ -813,6 +814,21 @@ Certipy v4.7.0 - by Oliver Lyak (ly4k)
 [*] Certificate object SID is 'S-1-5-21-980154951-4172460254-2779440654-500'
 [*] Saved certificate and private key to 'administrator.pfx'
 [*] Exiting...
+```
+#### ESC14
+
+ESC14 is when a user has write access to the `altSecurityIdentities` attribute of a target account (ESC14 A) or when a weak certificate mapping is configured on a target account (ESC14 B-C-D).
+
+In the case of an ESC14 A, we can enroll on a certificate and create an explicit mapping on the target account by modifying its `altSecurityIdentities` attribute and pointing it to the certificate obtained. This certificate can then be used to authenticate as the target.
+
+In the case of an ESC14 B-C-D, the target is configured with a weak explicit mapping that can be abused by modifying the relevant attributes on a separate victim account to match the explicit mapping of the target. We can then enroll on a certificate as the victim, and use this same certificate to authenticate as the target.
+
+There are a number of conditions on certificate templates or other configuration elements that affect the use of ESC14. See the original [blog post](https://posts.specterops.io/adcs-esc14-abuse-technique-333a004dc2b9) for more information. 
+
+The `find`command below identifies users configured with weak explicit mapping.
+
+```bash
+$ certipy find -u john@corp.local -p Passw0rd -dc-ip 172.16.126.128 -esc14
 ```
 
 ## Contact

--- a/README.md
+++ b/README.md
@@ -825,7 +825,7 @@ In the case of an ESC14 B-C-D, the target is configured with a weak explicit map
 
 There are a number of conditions on certificate templates or other configuration elements that affect the use of ESC14. See the original [blog post](https://posts.specterops.io/adcs-esc14-abuse-technique-333a004dc2b9) for more information. 
 
-The `find`command below identifies users configured with weak explicit mapping.
+The `find`command below identifies users and computers   configured with weak explicit mapping.
 
 ```bash
 $ certipy find -u john@corp.local -p Passw0rd -dc-ip 172.16.126.128 -esc14

--- a/certipy/commands/parsers/find.py
+++ b/certipy/commands/parsers/find.py
@@ -70,7 +70,11 @@ def add_subparser(subparsers: argparse._SubParsersAction) -> Tuple[str, Callable
         action="store_true",
         help="Don't show administrator permissions for -text, -stdout, and -json. Does not affect BloodHound output",
     )
-
+    group.add_argument(
+        "-esc14",
+        action="store_true",
+        help="Search for ESC14 vulnerability (warning, may take some time). Not compatible with BloodHound output",
+    )
     group = subparser.add_argument_group("connection options")
     group.add_argument(
         "-scheme",

--- a/certipy/commands/parsers/find.py
+++ b/certipy/commands/parsers/find.py
@@ -73,7 +73,7 @@ def add_subparser(subparsers: argparse._SubParsersAction) -> Tuple[str, Callable
     group.add_argument(
         "-esc14",
         action="store_true",
-        help="Search for ESC14 vulnerability (warning, may take some time). Not compatible with BloodHound output",
+        help="Search for ESC14 vulnerability (warning, may take some time). Not compatible with BloodHound or JSON output",
     )
     group = subparser.add_argument_group("connection options")
     group.add_argument(


### PR DESCRIPTION
Added the detection of users and computers configured with weak certificate mapping as part of ESC14 detection (cf. https://posts.specterops.io/adcs-esc14-abuse-technique-333a004dc2b9)

```
certipy find -u john@corp.local -p Passw0rd -dc-ip 172.16.126.128 -esc14
```

The use of this flag only affects the console output and the .txt file as to not disrupt other tools (e.g. BloodHound ingestor).

As the requirements are [very specific](https://github.com/JonasBK/ESC14/blob/main/ESC14-Table.xlsx) and weak certificate mappings are due to be rendered inusable by [September 2025](https://support.microsoft.com/en-us/topic/kb5014754-certificate-based-authentication-changes-on-windows-domain-controllers-ad2c23b0-15d8-4340-a468-4d4f3b188f16), the step of identifying usable certificate templates is still manual.

*Identification of users with weak certificate mapping*
<img width="818" alt="Certipy_ESC14_1" src="https://github.com/user-attachments/assets/b423d6d6-6b6d-408b-a406-4378a46af45c" />


*Details found in the .txt file*
<img width="483" alt="Certipy_ESC14_2" src="https://github.com/user-attachments/assets/18ecc3ef-e122-45d2-80e5-a724ddd980d7" />

