### PR TITLE
Disable Multi-Relay

### DIFF
--- a/certipy/commands/relay.py
+++ b/certipy/commands/relay.py
@@ -677,6 +677,7 @@ class Relay:
 
         config = NTLMRelayxConfig()
         config.setTargets(target)
+        config.setDisableMulti(True)
         config.setIsADCSAttack(True)
         config.setADCSOptions(self.template)
         config.setAttacks(


### PR DESCRIPTION
Multi-relay breaks relaying when the client requires signing (see https://www.thehacker.recipes/ad/movement/ntlm/relay):

![image](https://github.com/user-attachments/assets/9e122056-4bb0-4dac-8e2d-f6115ee245bc)

Fixes https://github.com/ly4k/Certipy/issues/227