### PR TITLE
C4pi/simple auth fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ The `find` command is useful for enumerating AD CS certificate templates, certif
 Certipy v4.0.0 - by Oliver Lyak (ly4k)
 
 usage: certipy find [-h] [-debug] [-bloodhound] [-old-bloodhound] [-text] [-stdout] [-json] [-output prefix] [-enabled] [-dc-only] [-vulnerable] [-hide-admins] [-scheme ldap scheme] [-dc-ip ip address] [-target-ip ip address] [-target dns/ip address] [-ns nameserver] [-dns-tcp]
-                    [-timeout seconds] [-u username@domain] [-p password] [-hashes [LMHASH:]NTHASH] [-k] [-sspi] [-aes hex key] [-no-pass]
+                    [-timeout seconds] [-u username@domain] [-p password] [-hashes [LMHASH:]NTHASH] [-k] [-simple-auth] [-sspi] [-aes hex key] [-no-pass]
 
 optional arguments:
   -h, --help            show this help message and exit
@@ -113,6 +113,7 @@ authentication options:
   -hashes [LMHASH:]NTHASH
                         NTLM hash, format is [LMHASH:]NTHASH
   -k                    Use Kerberos authentication. Grabs credentials from ccache file (KRB5CCNAME) based on target parameters. If valid credentials cannot be found, it will use the ones specified in the command line
+  -simple-auth          Use SIMPLE authentication instead of NTLM
   -sspi                 Use Windows Integrated Authentication (SSPI)
   -aes hex key          AES key to use for Kerberos Authentication (128 or 256 bits)
   -no-pass              Don't ask for password (useful for -k and -sspi)
@@ -169,7 +170,7 @@ Certipy v4.0.0 - by Oliver Lyak (ly4k)
 
 usage: certipy req [-h] [-debug] -ca certificate authority name [-template template name] [-upn alternative UPN] [-dns alternative DNS] [-subject subject] [-retrieve request ID] [-on-behalf-of domain\account] [-pfx pfx/p12 file name] [-key-size RSA key length] [-archive-key]
                    [-renew] [-out output file name] [-web] [-dynamic-endpoint] [-scheme http scheme] [-port PORT] [-dc-ip ip address] [-target-ip ip address] [-target dns/ip address] [-ns nameserver] [-dns-tcp] [-timeout seconds] [-u username@domain] [-p password]
-                   [-hashes [LMHASH:]NTHASH] [-k] [-sspi] [-aes hex key] [-no-pass]
+                   [-hashes [LMHASH:]NTHASH] [-k] [-simple-auth] [-sspi] [-aes hex key] [-no-pass]
 
 optional arguments:
   -h, --help            show this help message and exit
@@ -220,6 +221,7 @@ authentication options:
   -hashes [LMHASH:]NTHASH
                         NTLM hash, format is [LMHASH:]NTHASH
   -k                    Use Kerberos authentication. Grabs credentials from ccache file (KRB5CCNAME) based on target parameters. If valid credentials cannot be found, it will use the ones specified in the command line
+  -simple-auth          Use SIMPLE authentication instead of NTLM
   -sspi                 Use Windows Integrated Authentication (SSPI)
   -aes hex key          AES key to use for Kerberos Authentication (128 or 256 bits)
   -no-pass              Don't ask for password (useful for -k and -sspi)
@@ -319,7 +321,7 @@ The `shadow` command is useful for taking over an account when you can write to 
 Certipy v4.0.0 - by Oliver Lyak (ly4k)
 
 usage: certipy shadow [-h] [-account target account] [-device-id DEVICE_ID] [-debug] [-out output file name] [-scheme ldap scheme] [-dc-ip ip address] [-target-ip ip address] [-target dns/ip address] [-ns nameserver] [-dns-tcp] [-timeout seconds] [-u username@domain]
-                      [-p password] [-hashes [LMHASH:]NTHASH] [-k] [-sspi] [-aes hex key] [-no-pass]
+                      [-p password] [-hashes [LMHASH:]NTHASH] [-k] [-simple-auth] [-sspi] [-aes hex key] [-no-pass]
                       {list,add,remove,clear,info,auto}
 
 positional arguments:
@@ -355,6 +357,7 @@ authentication options:
   -hashes [LMHASH:]NTHASH
                         NTLM hash, format is [LMHASH:]NTHASH
   -k                    Use Kerberos authentication. Grabs credentials from ccache file (KRB5CCNAME) based on target parameters. If valid credentials cannot be found, it will use the ones specified in the command line
+  -simple-auth          Use SIMPLE authentication instead of NTLM
   -sspi                 Use Windows Integrated Authentication (SSPI)
   -aes hex key          AES key to use for Kerberos Authentication (128 or 256 bits)
   -no-pass              Don't ask for password (useful for -k and -sspi)

--- a/certipy/commands/parsers/target.py
+++ b/certipy/commands/parsers/target.py
@@ -81,6 +81,12 @@ def add_argument_group(
         "ones specified in the command line",
     )
     group.add_argument(
+        "-simple-auth",
+        action="store_true",
+        dest="do_simple",
+        help="Use SIMPLE authentication instead of NTLM",
+    )
+    group.add_argument(
         "-sspi",
         dest="use_sspi",
         action="store_true",

--- a/certipy/lib/target.py
+++ b/certipy/lib/target.py
@@ -152,6 +152,7 @@ class Target:
         self.lmhash: str = None
         self.nthash: str = None
         self.do_kerberos: bool = False
+        self.do_simple: bool = False
         self.use_sspi: bool = False
         self.aes: str = None
         self.dc_ip: str = None
@@ -264,6 +265,7 @@ class Target:
         self.nthash = nthash
         self.aes = options.aes
         self.do_kerberos = options.do_kerberos
+        self.do_simple = options.do_simple
         self.use_sspi = options.use_sspi
         self.dc_ip = dc_ip
         self.dc_host = dc_host
@@ -300,6 +302,7 @@ class Target:
         remote_name: str = None,
         no_pass: bool = False,
         do_kerberos: bool = False,
+        do_simple: bool = False,
         use_sspi: bool = False,
         aes: str = None,
         dc_ip: str = None,
@@ -362,6 +365,7 @@ class Target:
         self.nthash = nthash
         self.aes = aes
         self.do_kerberos = do_kerberos
+        self.do_simple = do_simple
         self.use_sspi = use_sspi
         self.dc_ip = dc_ip
         self.timeout = timeout


### PR DESCRIPTION
This MR adds the SIMPLE auth LDAP method to the allowed connection methods.
It can be used with the "-simple-auth" option directly from the command-line.

It affects the following commands:
- find
- req
- shadow
- account
- ca
- template
The behaviour is different only when the `-simple-auth` option is used so it will not break the tool workflow.

It uses the ldap3 "Connection" class just like the other auth methods.
This can be useful when neither Kerberos nor NTLM protocols are available (rare but possible).

README was updated but further documentation may need to be updated to show the new option for "-simple-auth".


