### PR TITLE
Fix issue with attribute not found

### DIFF
--- a/certipy/commands/find.py
+++ b/certipy/commands/find.py
@@ -96,6 +96,7 @@ class Find:
         self.kwargs = kwargs
 
         self._connection = connection
+        self._user_sids = None
 
     # =========================================================================
     # Connection Handling


### PR DESCRIPTION
Issue:

```
certipy -debug find -u $USER@$DOMAIN -p $PASSWORD -dc-ip $DCIP -ldap-scheme ldap -vulnerable
Certipy v5.0.0 - by Oliver Lyak (ly4k)

[+] Trying to resolve 'HACKN.LAB' at '10.10.10.101'
[+] Authenticating to LDAP server using NTLM authentication
[+] Using NTLM signing: True (LDAP signing: True, SSL: False)
[+] Using channel binding signing: False (LDAP channel binding: True, SSL: False)
[+] LDAP NTLM authentication successful
[+] Bound to ldap://10.10.10.102:389 - cleartext
[+] Default path: DC=hackn,DC=lab
[+] Configuration path: CN=Configuration,DC=hackn,DC=lab
[-] Got error: 'Find' object has no attribute '_user_sids'
Traceback (most recent call last):
  File "/home/pixis/.local/share/pipx/venvs/certipy-ad/lib/python3.12/site-packages/certipy/entry.py", line 68, in main
    actions[options.action](options)
  File "/home/pixis/.local/share/pipx/venvs/certipy-ad/lib/python3.12/site-packages/certipy/commands/parsers/find.py", line 30, in entry
    find.entry(options)
  File "/home/pixis/.local/share/pipx/venvs/certipy-ad/lib/python3.12/site-packages/certipy/commands/find.py", line 2403, in entry
    find.find()
  File "/home/pixis/.local/share/pipx/venvs/certipy-ad/lib/python3.12/site-packages/certipy/commands/find.py", line 277, in find
    sids = self.user_sids
           ^^^^^^^^^^^^^^
  File "/home/pixis/.local/share/pipx/venvs/certipy-ad/lib/python3.12/site-packages/certipy/commands/find.py", line 128, in user_sids
    if self._user_sids is None:
       ^^^^^^^^^^^^^^^
AttributeError: 'Find' object has no attribute '_user_sids'. Did you mean: 'user_sids'?
```