### PR TITLE
Missing OID Remote Desktop Authentication

### DIFF
--- a/certipy/lib/constants.py
+++ b/certipy/lib/constants.py
@@ -468,6 +468,7 @@ OID_TO_STR_MAP = {
     # Standard certificate usages
     "1.3.6.1.5.5.7.3.1": "Server Authentication",
     "1.3.6.1.5.5.7.3.2": "Client Authentication",
+    "1.3.6.1.4.1.311.54.1.2": "Remote Desktop Authentication",
     "1.3.6.1.5.5.7.3.3": "Code Signing",
     "1.3.6.1.5.5.7.3.4": "Secure Email",
     "1.3.6.1.5.5.7.3.5": "IP security end system",


### PR DESCRIPTION
https://techcommunity.microsoft.com/blog/askds/remote-desktop-services-enrolling-for-tls-certificate-from-an-enterprise-ca/4137437