### PR TITLE
Shell Completions

### DIFF
--- a/certipy/entry.py
+++ b/certipy/entry.py
@@ -1,6 +1,9 @@
+# PYTHON_ARGCOMPLETE_OK
 import argparse
 import logging
 import sys
+
+import argcomplete
 
 from certipy import version
 from certipy.commands.parsers import ENTRY_PARSERS
@@ -51,6 +54,8 @@ def main() -> None:
     for entry_parser in ENTRY_PARSERS:
         action, entry = entry_parser.add_subparser(subparsers)
         actions[action] = entry
+
+    argcomplete.autocomplete(parser, always_complete_options=False)
 
     if len(sys.argv) == 1:
         parser.print_help()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
     "pycryptodome~=3.22.0",
     "bs4~=0.0.2",
     "httpx~=0.28.1",
+    "argcomplete~=3.6.2",
 ]
 
 [project.urls]


### PR DESCRIPTION
This small patch introduces [argcomplete](https://github.com/kislyuk/argcomplete) to enable Certipy to autogenerate shell completions.

Once enabled by the user, shell completions make using Certipy more efficient. The following screenshots show the completions used with the fish shell :fish: (but this works with other shells like bash and zsh, too).

![subcommands](https://github.com/user-attachments/assets/77b7d6d5-ba13-4822-a4c7-dc845f8f5dda)
![options](https://github.com/user-attachments/assets/08ea256e-d31b-4b41-8161-4230d00d8669)

Now users need to know this feature exists. I propose that a section like the following is added to the [Installation wiki page](https://github.com/ly4k/Certipy/wiki/04-%E2%80%90-Installation) somewhere:

```markdown
### Shell Completions

Certipy uses [argcomplete](https://github.com/kislyuk/argcomplete) to autogenerate tab completions for your shell (bash, zsh, fish, ...).
See the `argcomplete` README for how to enable tab completions.
```