### PR TITLE
Issue templates: use code block formatting for certain textareas

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -32,6 +32,7 @@ body:
     attributes:
       label: 📥 Command Used
       description: Include the full (but redacted) command that triggered the issue
+      render: shell
       placeholder: |
         Example:
         certipy req -u user@redacted.local -p 'REDACTED' -ca CORP-CA -template ESC1 -upn admin@redacted.local
@@ -43,6 +44,7 @@ body:
     attributes:
       label: 🧯 Error Message / Unexpected Output
       description: Paste any output, error messages, or tracebacks (redacted if needed)
+      render: text
       placeholder: |
         Example:
         Traceback (most recent call last):
@@ -56,6 +58,7 @@ body:
     attributes:
       label: 🔍 Relevant `certipy find` Output (abbreviated and redacted)
       description: If this bug is related to vulnerability detection or escalation, please include redacted highlights from `certipy find`.
+      render: text
       placeholder: |
         Certificate Authorities
           0

--- a/.github/ISSUE_TEMPLATE/help_request.yml
+++ b/.github/ISSUE_TEMPLATE/help_request.yml
@@ -52,6 +52,7 @@ body:
     attributes:
       label: 🔍 Relevant `certipy find` Output (abbreviated and redacted)
       description: If this bug is related to vulnerability detection or escalation, please include redacted highlights from `certipy find`.
+      render: text
       placeholder: |
         Certificate Authorities
           0


### PR DESCRIPTION
The new issue templates request the reporter to paste some console output. Since there is no automatic code block formatting, this makes error output hardly readable. I think reporters will often forget to manually use code block formatting, since the issue template structure makes this less obvious than with the previous free form.  (And even then, some people don't care to format their issue reports.)

This PR enables code block formatting for the textareas which are likely to contain console input/output.