### PR TITLE
Fix dummy bs4 dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
     "pyopenssl~=24.0.0",
     "requests~=2.32.3",
     "pycryptodome~=3.22.0",
-    "bs4~=0.0.2",
+    "beautifulsoup4~=4.13.4",
     "httpx~=0.28.1",
     "argcomplete~=3.6.2",
 ]


### PR DESCRIPTION
bs4 is a dummy dependency. Changed to use beautifulsoup4 instead

https://pypi.org/project/bs4/
https://pypi.org/project/beautifulsoup4/