### PR TITLE
Switching to single quotes to fix syntax error

### DIFF
--- a/certipy/commands/shadow.py
+++ b/certipy/commands/shadow.py
@@ -493,7 +493,7 @@ class Shadow:
             )
 
             logging.info(
-                f"DeviceID: {key_credential_device_id or "Unknown"} | "
+                f"DeviceID: {key_credential_device_id or 'Unknown'} | "
                 f"Creation Time (UTC): {creation_time_str}"
             )
 


### PR DESCRIPTION
Newly added double quotes was causing syntax error