### PR TITLE
Fix target DC resolution for the auth command

### DIFF
--- a/certipy/commands/auth.py
+++ b/certipy/commands/auth.py
@@ -183,8 +183,6 @@ class Authenticate:
         self,
         target: Target,
         pfx: Optional[str] = None,
-        username: Optional[str] = None,
-        domain: Optional[str] = None,
         password: Optional[str] = None,
         cert: Optional[x509.Certificate] = None,
         key: Optional[PrivateKeyTypes] = None,
@@ -201,8 +199,6 @@ class Authenticate:
         Args:
             target: Target information (domain, DC IP, etc.)
             pfx: Path to PFX/P12 certificate file
-            username: Username to authenticate as
-            domain: Domain to authenticate to
             password: Password for PFX file
             cert: Pre-loaded certificate object
             key: Pre-loaded private key object
@@ -218,8 +214,6 @@ class Authenticate:
             **kwargs: Additional parameters
         """
         self.target = target
-        self.username = username
-        self.domain = domain
         self.pfx = pfx
         self.password = password
         self.cert = cert
@@ -278,10 +272,10 @@ class Authenticate:
 
         # Resolve username and domain from target if not provided
         if not username:
-            username = self.username or self.target.username
+            username = self.target.username
 
         if not domain:
-            domain = self.domain or self.target.domain
+            domain = self.target.domain
 
         # Use LDAP authentication if requested
         if self.ldap_shell:

--- a/certipy/lib/target.py
+++ b/certipy/lib/target.py
@@ -138,6 +138,7 @@ class Target:
 
         # Authentication options
         principal = options.username if hasattr(options, "username") else None
+        domain = options.domain if hasattr(options, "domain") else ""
         password = options.password if hasattr(options, "password") else None
         hashes = options.hashes if hasattr(options, "hashes") else None
 
@@ -164,7 +165,6 @@ class Target:
         )
 
         # Parse username and domain from principal format (user@DOMAIN)
-        domain = ""
         username = ""
 
         if principal is not None:
@@ -173,8 +173,13 @@ class Target:
                 username = parts[0]
             else:
                 username = "@".join(parts[:-1])
-                domain = parts[-1]
-
+                if not domain:
+                    domain = parts[-1]
+                else:
+                    logging.warning(
+                        f"Domain specified in both principal and options: {domain!r} and {parts[-1]!r}. Using {domain!r}"
+                    )
+        
         # Handle Kerberos authentication
         if do_kerberos:
             principal = get_kerberos_principal()


### PR DESCRIPTION
The `auth` command relies on the Target class to identify the DC to talk to. The target class however did not consider the `auth` command's `-domain` parameter, yet. This resulted in a failed target resultion, if the username was not a principal (username@domain). Providing a principal in turn clashed with the `-domain` parameter, as this was blindly appended during authentication.  

This pull request fixes this while it should preserve the existing CLI. Further, it enables the provision of a principal as username. 