### PR TITLE
Support Outflank C2 reg query command

### DIFF
--- a/certipy/commands/parsers/parse.py
+++ b/certipy/commands/parsers/parse.py
@@ -92,7 +92,7 @@ def add_subparser(subparsers: argparse._SubParsersAction) -> Tuple[str, Callable
         "-format",
         metavar="format",
         help="Input format: BOF output or Windows .reg file (default: bof)",
-        choices=["bof", "reg"],
+        choices=["bof", "reg", "oc2_bof"],
         default="bof",
     )
     parse_group.add_argument(


### PR DESCRIPTION
The Outflank C2 reg query command outputs registry data in a different format than `.reg` files. This PR allows parsing this format in addition to `.reg` files.