### PR TITLE
Allow resolving and obtaining SIDs using bloodhound

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Install Certipy
         run: |
-          pip install -e .
+          pip install -e .[bloodhound]
 
       - name: Lint with flake8 (style and naming)
         run: |

--- a/certipy/commands/parsers/parse.py
+++ b/certipy/commands/parsers/parse.py
@@ -143,4 +143,19 @@ def add_subparser(subparsers: argparse._SubParsersAction) -> Tuple[str, Callable
         help="Don't show administrator permissions for -text, -stdout, -json, and -csv output",
     )
 
+    bloodhound_group = subparser.add_argument_group(
+        "BloodHound", description="Requires the 'bloodhound' extra to be installed"
+    )
+    bloodhound_group.add_argument("-neo4j-user", help="Username for neo4j")
+    bloodhound_group.add_argument("-neo4j-pass", help="Password for neo4j")
+    bloodhound_group.add_argument(
+        "-neo4j-host", help="Host for neo4j", default="localhost"
+    )
+    bloodhound_group.add_argument("-neo4j-port", help="Port for neo4j", default=7687)
+    bloodhound_group.add_argument(
+        "-use-owned-sids",
+        help="Use the SIDs of all owned principals as the user SIDs",
+        action="store_true",
+    )
+
     return NAME, entry

--- a/certipy/lib/bloodhound.py
+++ b/certipy/lib/bloodhound.py
@@ -1,0 +1,43 @@
+from typing import Tuple
+
+
+class BloodHoundError(Exception):
+    pass
+
+
+def resolve_type(labels: frozenset[str]):
+    for type in ["User", "Group", "Computer"]:
+        if type in labels:
+            return type.upper()
+    return "UNKNOWN"
+
+
+class BloodHound:
+    def __init__(
+        self, user: str, password: str, host: str = "localhost", port: int = 7687
+    ):
+        try:
+            from neo4j import GraphDatabase
+        except ImportError:
+            raise BloodHoundError(
+                "Please install the 'bloodhound' extra to use this feature"
+            )
+        self.driver = GraphDatabase.driver(
+            f"neo4j://{host}:{port}",
+            auth=(user, password),
+        )
+
+    def get_owned_sids(self):
+        records, _, _ = self.driver.execute_query(
+            "MATCH (u:User)-[:MemberOf*1..]->(g:Group) WHERE COALESCE(u.system_tags, '') CONTAINS 'owned' return g.objectid"
+        )
+        for record in records:
+            yield record["g.objectid"]
+
+    def lookup_sid(self, sid: str) -> Tuple[str, str]:
+        records, _, _ = self.driver.execute_query(
+            "MATCH (g {objectid:$sid}) return g", sid=sid
+        )
+        if records:
+            return records[0]["g"]["name"], resolve_type(records[0]["g"].labels)
+        raise BloodHoundError("SID not found")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,11 @@ dependencies = [
     "argcomplete~=3.6.2",
 ]
 
+[project.optional-dependencies]
+bloodhound = [
+    "neo4j~=5.28.1",
+]
+
 [project.urls]
 Homepage = "https://github.com/ly4k/Certipy"
 "Bug Tracker" = "https://github.com/ly4k/Certipy/issues"


### PR DESCRIPTION
Allow using BloodHound to resolve SIDs dynamically and for obtaining the SIDs of owned users during parsing registry output.