### PR TITLE
Add All-Extended-Rights check to Access Allowed Ace

### DIFF
--- a/certipy/lib/security.py
+++ b/certipy/lib/security.py
@@ -96,6 +96,11 @@ class ActiveDirectorySecurity(SecurityDescriptorParser):
             if ace["AceType"] == ldaptypes.ACCESS_ALLOWED_ACE.ACE_TYPE:
                 self.aces[sid]["rights"] |= self.RIGHTS_TYPE(ace["Ace"]["Mask"]["Mask"])
 
+                if ace["Ace"]["Mask"].hasPriv(
+                    ldaptypes.ACCESS_ALLOWED_OBJECT_ACE.ADS_RIGHT_DS_CONTROL_ACCESS
+                ):
+                    self.aces[sid]["extended_rights"].append(EXTENDED_RIGHTS_NAME_MAP["All-Extended-Rights"])
+
             # Process object-specific ACE (for extended rights)
             elif ace["AceType"] == ldaptypes.ACCESS_ALLOWED_OBJECT_ACE.ACE_TYPE and ace[
                 "Ace"

--- a/certipy/lib/security.py
+++ b/certipy/lib/security.py
@@ -99,7 +99,9 @@ class ActiveDirectorySecurity(SecurityDescriptorParser):
                 if ace["Ace"]["Mask"].hasPriv(
                     ldaptypes.ACCESS_ALLOWED_OBJECT_ACE.ADS_RIGHT_DS_CONTROL_ACCESS
                 ):
-                    self.aces[sid]["extended_rights"].append(EXTENDED_RIGHTS_NAME_MAP["All-Extended-Rights"])
+                    self.aces[sid]["extended_rights"].append(
+                        EXTENDED_RIGHTS_NAME_MAP["All-Extended-Rights"]
+                    )
 
             # Process object-specific ACE (for extended rights)
             elif ace["AceType"] == ldaptypes.ACCESS_ALLOWED_OBJECT_ACE.ACE_TYPE and ace[


### PR DESCRIPTION
As previously mentioned in https://github.com/ly4k/Certipy/pull/177, there is still a missing check for All Extended Rights when parsing Access Allowed Aces