### PR TITLE
Allow python 3.10 and call print function for each line

### DIFF
--- a/certipy/lib/formatting.py
+++ b/certipy/lib/formatting.py
@@ -96,11 +96,17 @@ def pretty_print(
                     else:
                         print_func(f"{indent_str}  {item}")
             else:
-                # Format list with line breaks if needed
-                formatted_list = ("\n" + " " * padding + "  ").join(
-                    str(x) for x in value
-                )
-                print_func(f"{padded_key}: {formatted_list}")
+                if len(value) > 0:
+                    # Format list with line breaks if needed
+                    formatted_list = ("\n" + " " * padding + "  ").join(
+                        str(x) for x in value
+                    ).splitlines()
+                    first_item = formatted_list.pop(0)
+                    print_func(f"{padded_key}: {first_item}")
+                    for item in formatted_list:
+                        print_func(f"{item}")
+                else:
+                    print_func(f"{padded_key}:")
 
         elif isinstance(value, tuple):
             # Handle tuples (similar to lists of dictionaries)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ authors = [
     {name = "ly4k"}
 ]
 license = {text = "MIT"}
-requires-python = ">=3.12"
+requires-python = ">=3.10"
 classifiers = [
     "Programming Language :: Python :: 3",
     "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
Hi and thanks for your work!

I am currently trying to integrate the certipy lib into [NetExec](https://github.com/Pennyw0rth/NetExec). However, in order to get that working i need to:
1. Allow python to be >= 3.10 (which should not be a problem as far as i can tell)
2. Fix behavior of the `pretty_print()` function to call the `print_func` for each individual line

The latter is needed, because NetExec applies its own prefixes to each output line. Therefore, for each new line there needs to be a separate call to the print function. Here is the "before" and "after" of that change:
<img width="1153" height="728" alt="image" src="https://github.com/user-attachments/assets/4deed024-41ba-4f5d-bd1d-32ffa4e7c461" />
<img width="1133" height="425" alt="image" src="https://github.com/user-attachments/assets/c63d34fc-982c-43e8-9e02-c6b313626d72" />
