### PR TITLE
channel binding tautology cli argument

### DIFF
--- a/certipy/commands/parsers/req.py
+++ b/certipy/commands/parsers/req.py
@@ -208,7 +208,7 @@ def add_subparser(subparsers: argparse._SubParsersAction) -> Tuple[str, Callable
     )
     http_group.add_argument(
         "-no-channel-binding",
-        action="store_true",
+        action="store_false",
         help="Disable channel binding for HTTP connections",
     )
 


### PR DESCRIPTION
channel binding could only ever take on one logical value (my case was when -k and -web was used concurrently). It's perhaps also worth noting that afaik, ~~channel binding and simple auth is controlled by the same registry flag on the DC~~* . So it doesn't make sense to do channel binding over ldap simple auth**. 

*it's not. 
**still holds