### PR TITLE
Fix ESC1 false negatives in template enumeration

### DIFF
--- a/certipy/commands/find.py
+++ b/certipy/commands/find.py
@@ -2110,23 +2110,29 @@ class Find:
         enrollable_sids = []
         user_can_enroll = False
 
-        # Check ACEs for enrollment rights
+        # Check ACEs for enrollment rights per MS-CRTD rules
         for sid, rights in security.aces.items():
             if sid not in user_sids:
                 continue
 
-            # Check for enrollment rights (All-Extended-Rights, Enroll, or Generic All)
-            if (
-                (
-                    EXTENDED_RIGHTS_NAME_MAP["All-Extended-Rights"]
-                    in rights["extended_rights"]
-                    and rights["rights"] & ActiveDirectoryRights.EXTENDED_RIGHT
-                )
-                or (
-                    EXTENDED_RIGHTS_NAME_MAP["Enroll"] in rights["extended_rights"]
-                    and rights["rights"] & ActiveDirectoryRights.EXTENDED_RIGHT
-                )
-                or CertificateRights.GENERIC_ALL in rights["rights"]
+            # Rule 1: ACCESS_ALLOWED_OBJECT_ACE with control access and ObjectType == Enroll GUID
+            has_object_enroll = (
+                EXTENDED_RIGHTS_NAME_MAP["Enroll"] in rights["extended_rights"]
+                and rights["rights"] & ActiveDirectoryRights.EXTENDED_RIGHT
+            )
+
+            # Preserve behavior: All-Extended-Rights also implies enrollment
+            has_all_extended = (
+                EXTENDED_RIGHTS_NAME_MAP["All-Extended-Rights"] in rights["extended_rights"]
+                and rights["rights"] & ActiveDirectoryRights.EXTENDED_RIGHT
+            )
+
+            # Rule 2: ACCESS_ALLOWED_ACE with control access bit set (0x00000100)
+            # Captured by security parser as 'has_standard_control_access'
+            has_standard_control_access = rights.get("has_standard_control_access", False)
+
+            if has_object_enroll or has_all_extended or has_standard_control_access or (
+                CertificateRights.GENERIC_ALL in rights["rights"]
             ):
                 enrollable_sids.append(sid)
                 user_can_enroll = True


### PR DESCRIPTION
## Summary
This PR improves ESC1 detection in Certipy by addressing false negatives observed in specific template configurations. The change refines the logic that determines whether a template is exploitable for ESC1.

## Background
According to Microsoft documentation ([MS-CRTD: Certificate Templates Structure](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-crtd/4be42fa6-c421-4763-890b-07a9ab5a319d)) enrollment permissions for a certificate template are evaluated based on two processing rules:

**First rule**
- The requester SID matches the SID associated with the ACE.  
- The ACE type is `ACCESS_ALLOWED_OBJECT_ACE`.  
- The access mask has the bit `0x00000100` set (Control Access).  
- The `ObjectType` field corresponds to the Enroll GUID (`0e10c968-78fb-11d2-90d4-00c04f79dc55`).  

**Second rule**
- The requester SID matches the SID associated with the ACE.  
- The ACE type is `ACCESS_ALLOWED_ACE`.  
- The access mask has the bit `0x00000100` set.  

These rules define how Active Directory evaluates whether a principal can enroll for a certificate. In addition to Microsoft’s specification, further practical details and lab-based examples can be found in my previous articles [*The Schrödinger’s ESC1 Vulnerability*](https://medium.com/@vilachamatheus/the-schr%C3%B6dingers-esc1-vulnerability-ec1cee0cd9b8) and [*The Schrödinger’s ESC1 Vulnerability: Benchmark Update*](https://medium.com/@vilachamatheus/the-schr%C3%B6dingers-esc1-vulnerability-benchmark-update-e9a24421850b), where these conditions were analyzed across different tool implementations.

## Problem
In some scenarios, Certipy failed to flag templates as ESC1-vulnerable even when they were exploitable. This was reproducible in a controlled lab with eight dedicated templates (four vulnerable, four non-vulnerable).

## Root Cause
In `certipy/commands/find.py`, the function **`can_user_enroll_in_template`** does not implement both enrollment-processing rules defined by Microsoft’s specification (MS-CRTD). The current logic effectively checks only **Rule 1** by validating the presence of the Enroll (or All-Extended-Rights) object-specific extended right. Because an ACE with an `ObjectType` is, by definition, an `ACCESS_ALLOWED_OBJECT_ACE`, the function implicitly assumes the ACE type and does not verify it explicitly.  

As a result, **Rule 2** is not considered. This omission leads to false negatives in cases where enrollment is legitimately granted through a standard ACE with Control Access.

## Solution

### Key changes
- **`certipy/lib/security.py` (ActiveDirectorySecurity parser)**
  - Record a new flag `has_standard_control_access` when a standard `ACCESS_ALLOWED_ACE` has the Control Access bit (`0x00000100`) set.  
  - Continue collecting object-specific extended-rights GUIDs (including Enroll and All-Extended-Rights).  

- **`certipy/commands/find.py` (`can_user_enroll_in_template`)**
  - **Apply Rule 1 (MS-CRTD):** grant enrollment if there is an object ACE with Control Access whose `ObjectType` is the Enroll GUID (detected via presence of Enroll in `extended_rights` and the EXTENDED_RIGHT bit).  
  - Preserve existing handling of All-Extended-Rights.  
  - **Apply Rule 2 (MS-CRTD):** grant enrollment if there is a standard ACE with the Control Access bit set (via the new `has_standard_control_access` flag).  
  - Keep GENERIC_ALL as an additional grant condition.  

### What this means
Enrollment rights are now determined exactly per **MS-CRTD**:
- Rule 1: `ACCESS_ALLOWED_OBJECT_ACE` + Control Access + Enroll GUID.  
- Rule 2: `ACCESS_ALLOWED_ACE` (standard) + Control Access bit.  
- Still accepts All-Extended-Rights and Generic All as valid grants.  

This aligns Certipy’s behavior with the spec and eliminates the observed false negatives for templates that rely on a standard Control Access grant.

## Testing

- **Environment:** Terraform + GCP lab consisting of a Domain Controller, a Certificate Authority, a Windows Server (for .exe and .ps1 tools), and an Ubuntu machine (for Python tools).  
- **Vulnerable templates:** Four vulnerable certificate templates, with screenshots of their security descriptors and the corresponding vulnerable ACEs included.  

  - **TestCase1**
    - ACE Type: ACCESS_ALLOWED_OBJECT_ACE
    - Principal: Domain Users group
    - Access Mask: 0x00000130
    - Object GUID: 0e10c968–78fb-11d2–90d4–00c04f79dc55  

  - **TestCase2**
    - ACE Type: ACCESS_ALLOWED_OBJECT_ACE
    - Principal: Specific low-privileged user (alice)
    - Access Mask: 0x00000130
    - Object GUID: 0e10c968–78fb-11d2–90d4–00c04f79dc55  

  - **TestCase3**
    - ACE Type: ACCESS_ALLOWED_ACE
    - Principal: Domain Users group
    - Access Mask: 0x00000100

  - **TestCase4**
    - ACE Type: ACCESS_ALLOWED_OBJECT_ACE
    - Principal: Specific low-privileged user (alice)
    - Access Mask: 0x00000100

- **Reproduction:**  
  1. Run `certipy find` using the modified version of Certipy ([*this branch*](https://github.com/vilacham/Certipy/tree/fix-esc1-false-negatives)).  
     <img width="1903" height="338" alt="2025-09-05 01_39_27" src="https://github.com/user-attachments/assets/94b51a9b-ccb9-4cd6-8ee4-e51f45c34f43" />
     <img width="1903" height="739" alt="2025-09-05 01_40_11" src="https://github.com/user-attachments/assets/107ce0a1-5dcb-424c-865f-e24b84996fc8" />  
     <img width="1903" height="627" alt="2025-09-05 01_40_49" src="https://github.com/user-attachments/assets/17331642-ab38-49a7-aeb4-ebdde7698560" />  
     <img width="1903" height="610" alt="2025-09-05 01_41_24" src="https://github.com/user-attachments/assets/f4809327-d784-41cc-9961-1932bcded634" />  
     <img width="1903" height="660" alt="2025-09-05 01_41_46" src="https://github.com/user-attachments/assets/b1bf9df8-e263-4239-b2e6-fff217652e85" />  
     <img width="1903" height="676" alt="2025-09-05 01_42_20" src="https://github.com/user-attachments/assets/54591682-f7ef-4400-9068-c53015d7deac" />  

  2. Run the same command using the original Certipy release for comparison.  
     <img width="1903" height="306" alt="2025-09-05 01_44_42" src="https://github.com/user-attachments/assets/003748ec-851a-4d34-ab6b-c10486fb379a" />  
     <img width="1903" height="737" alt="2025-09-05 01_46_46" src="https://github.com/user-attachments/assets/c7995408-a4ee-4d09-8253-e91df6c3c03c" />  
     <img width="1903" height="675" alt="2025-09-05 01_47_12" src="https://github.com/user-attachments/assets/6d8a174c-9881-4db5-a151-7cc7447ca583" />  
     <img width="1903" height="676" alt="2025-09-05 01_47_33" src="https://github.com/user-attachments/assets/85f978d9-47e8-4711-ba34-d0019337c91e" />

  3. For the vulnerable cases where the original Certipy failed to detect ESC1 (false negatives), privilege escalation using certipy req and certipy auth was demonstrated to confirm that the templates were indeed exploitable.  
     <img width="1903" height="420" alt="2025-09-05 01_53_34" src="https://github.com/user-attachments/assets/849f15ae-c9c4-465c-ada7-5750c7dee71c" />  
     <img width="1903" height="421" alt="2025-09-05 01_55_10" src="https://github.com/user-attachments/assets/32125592-4fa3-4cb6-8030-2eb4fc0dad6b" />   

## Result 
All four vulnerable templates are now correctly reported as ESC1 by the modified Certipy.
