### PR TITLE
Fix Shadow Credential certification validation

### DIFF
--- a/certipy/commands/shadow.py
+++ b/certipy/commands/shadow.py
@@ -190,7 +190,7 @@ class Shadow:
         key, cert = shadow_credentials.createSelfSignedX509Certificate(
             subject=subject,
             nBefore=(-40 * 365),  # Not before: 40 years ago
-            nAfter=(40 * 365),  # Not after: 40 years in the future
+            nAfter=(40 * 365 * 3600 * 24),  # Not after: 40 years in the future
             kSize=2048,  # Key size
         )
         logging.info("Certificate generated")


### PR DESCRIPTION
Hello, currently, certificate generated with the `shadow` commands are only valid for ~8 hours even if the comments in the code say it should be 40 years.
This commit fixes the issue by correctly setting the `nAfter` to the 40 years.
Indeed, according to the [Documentation](https://www.pyopenssl.org/en/latest/api/crypto.html#OpenSSL.crypto.X509.gmtime_adj_notAfter), this time should be expressed in seconds.