### PR TITLE
ESC4: more targeted default ESC1 template

### DIFF
--- a/certipy/commands/parsers/template.py
+++ b/certipy/commands/parsers/template.py
@@ -76,10 +76,16 @@ def add_subparser(subparsers: argparse._SubParsersAction) -> Tuple[str, Callable
     )
     config_group.add_argument(
         "-write-default-configuration",
-        action="store_true",
+        nargs="?",
+        const="S-1-5-11",
+        default=None,
+        metavar="target sid",
         help=(
             "Apply the default Certipy ESC1 configuration to the certificate template. "
-            "This configures the template to be vulnerable to ESC1 attack."
+            "This configures the template to be vulnerable to ESC1 attack. "
+            "It accepts an optional argument for the target sid that should get ESC1 permissions "
+            "(default S-1-5-11 for authenticated users). "
+            "CAREFUL: If you specify a SID of an account not under your control, you lose the ability to restore!"
         ),
     )
 

--- a/certipy/lib/constants.py
+++ b/certipy/lib/constants.py
@@ -388,6 +388,7 @@ class CertificateRights(IntFlag):
     WRITE_DACL = 262144
     WRITE_OWNER = 524288
     GENERIC_WRITE = 131112
+    GENERIC_READ = 131220
     GENERIC_ALL = 983551
 
 


### PR DESCRIPTION
Adds optional target SID parameter to `-write-default-configuration`; the resulting ESC1 template configuration will grant ESC1 specifically to the specified account. This prevents having to grant those permissions to the broad group of authenticated users.

Fixes #330