### PR TITLE
Add ca-subpath feature and arguments

### DIFF
--- a/certipy/commands/parsers/relay.py
+++ b/certipy/commands/parsers/relay.py
@@ -65,6 +65,18 @@ def add_subparser(subparsers: argparse._SubParsersAction) -> Tuple[str, Callable
         ),
     )
 
+    # CA subpath (optional)
+    subparser.add_argument(
+        "-ca-subpath",
+        action="store",
+        metavar="path to ask certificate after /certsrv/",
+        required=False,
+        help=(
+            "Path to ask a certificate after /certsrv/"
+            "Example: /en-us/ for ESC8 (become http://ca.corp.local/certsrv/en-us/certfnsh.asp)"
+        ),
+    )
+
     # Certificate request parameters
     cert_group = subparser.add_argument_group("certificate request options")
     cert_group.add_argument(

--- a/certipy/commands/parsers/req.py
+++ b/certipy/commands/parsers/req.py
@@ -61,6 +61,18 @@ def add_subparser(subparsers: argparse._SubParsersAction) -> Tuple[str, Callable
         help="Name of the Certificate Authority to request certificates from. Required for RPC and DCOM methods",
     )
 
+    # CA subpath (optional)
+    subparser.add_argument(
+        "-ca-subpath",
+        action="store",
+        metavar="path to ask certificate after /certsrv/",
+        required=False,
+        help=(
+            "Path to ask a certificate after /certsrv/"
+            "Example: /en-us/ (become http://ca.corp.local/certsrv/en-us/certfnsh.asp)"
+        ),
+    )
+
     # Certificate request parameters
     cert_group = subparser.add_argument_group("certificate request options")
     cert_group.add_argument(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "certipy-ad"
-version = "5.0.4"
+version = "5.0.5"
 description = "Active Directory Certificate Services enumeration and abuse"
 readme = "README.md"
 authors = [


### PR DESCRIPTION
Add ca-subpath feature and arguments to take into account path variations when requesting certificates via the web.
Allows to override the fact that endpoints are hardcoded and enables you to make them dynamic, when the CA URL to ask certificate is http://ip/certsrv/en-US/certfnsh.asp, for example.

Example :

certipy req -u 'usr@lab.local' -p 'pwd' -dc-ip dcip -ca CA -template tpl -target-ip tip -web -no-channel-binding -ca-subpath '/en-US/'.

This is very useful when, in pentesting or red teaming, the target CA (to exploit ESC8, for example) returns a 404 error on /certsrv/certfnsh.asp and instead uses /certsrv/snip/certfnsh.asp.
