### PR TITLE
Referal ST fix

### DIFF
--- a/certipy/lib/kerberos.py
+++ b/certipy/lib/kerberos.py
@@ -938,6 +938,5 @@ def get_tgs(
 
     # Extract the username and domain from the client name
     username = "@".join(str(client_name).split("@")[:-1])
-    domain = client_name.realm or ""
 
     return kdc_rep, cast(type, cipher), cast(Key, session_key), username, domain

--- a/certipy/lib/target.py
+++ b/certipy/lib/target.py
@@ -249,7 +249,7 @@ class Target:
                 logging.debug(
                     "DC host (-dc-host) not specified. Using domain as DC host"
                 )
-                dc_host = domain
+                dc_host = None
 
         if not remote_name:
             if target_ip:


### PR DESCRIPTION
I recently had trouble authenticating using cross-realm kerberos tickets. Certipy didn't manage to retreive a valid ST for a service on a different domain and was also unable to authenticate when supplied with a valid cross-realm ST (manually through KRB5CCNAME).

I think this issue is also mentioned here #328 

This fixes both cases (and from my testing won't break any other, but this should be properly tested) : 
1. Full authentication chain with user provided password/AesKey or TGT
- When calling ```getKerberosTGS```, certipy populates the ```kdc_host``` value with the -dc-ip user supplied parameter or resolves the initial domain name to get a ```kdc_host``` value (ip address)
- This forces ```getKerberosTGS``` to always query the same kdc, resulting in a ```KDC_ERR_WRONG_REALM``` error
(Since this effectively means trying to acquire an ST for _SPN/DomainB_ by asking _DomainA KDC_)
- By using `None` for ```kdc_host```, `getKerberosTGS` impacket function handles the _kdc switching_ mechanism on it's own and the final ST is retrieved (just like _getST.py_ would)

2. User supplied ST
- When directly using a valid ST for _DomainB_, acquired by a _DomainA user_, the ```domain``` variable is extracted from the decoded **final ticket**
```python
# lib/kerberos.py l.934
# Step 4: Extract client information from ticket
ticket = decoder.decode(kdc_rep, asn1Spec=TGS_REP())[0]
client_name = Principal()
client_name = client_name.from_asn1(ticket, "crealm", "cname")

# Extract the username and domain from the client name
username = "@".join(str(client_name).split("@")[:-1])
domain = client_name.realm or "" # HERE

return kdc_rep, cast(type, cipher), cast(Key, session_key), username, domain
 ```
- This value is incorrect since the `realm` attribute of the decoded ST is relative to _DomainB_ and not the **initial identity** from _DomainA user_
- Using the already stored `domain` variable (extracted from cli parameter or parsed on the .ccache) fixes the missmatch

I'm aware this requires DNS resolution to work but when doing cross-realm authentication, I think it's a fair requirement to avoid a lot of coding addition.  