### PR TITLE
Proposing ESC17

### DIFF
--- a/certipy/commands/find.py
+++ b/certipy/commands/find.py
@@ -939,7 +939,9 @@ class Find:
         template.set("client_authentication", client_authentication)
 
         # Check for server authentication capability
-        server_authentication = "Server Authentication" in extended_key_usage or any_purpose
+        server_authentication = (
+            "Server Authentication" in extended_key_usage or any_purpose
+        )
         template.set("server_authentication", server_authentication)
 
         # Check for enrollment agent capability
@@ -1982,8 +1984,11 @@ class Find:
                 # ESC17: Server authentication with enrollee-supplied subject
                 if template.get("enrollee_supplies_subject"):
                     from pprint import pprint
+
                     pprint(template["attributes"])
-                if template.get("enrollee_supplies_subject") and template.get("server_authentication"):
+                if template.get("enrollee_supplies_subject") and template.get(
+                    "server_authentication"
+                ):
                     vulnerabilities["ESC17"] = (
                         f"Enrollee supplies subject "
                         "and template allows server authentication."


### PR DESCRIPTION
Earlier this year, @Coontzy1 from TrustedSec published a [blog post](https://trustedsec.com/blog/wsus-is-sus-ntlm-relay-attacks-in-plain-sight) in which he detailed how an attacker could abuse a misconfigured ADCS template to spoof a WSUS server and perform an NTLM relay attack.
@shaaati and I have extended this research by exploring how to leverage such templates to gain code execution on HTTPS-enabled WSUS clients: https://blog.digitrace.de/2026/01/using-adcs-to-attack-https-enabled-wsus-clients/

In short, with a template that allows to supply the SAN and allows server authentication you can:
- Request a valid certificate for a WSUS server
- Intercept WSUS client traffic (e.g., via ARP spoofing on the local network)
- Serve a malicious Windows Update which is executed with local admin privs

This is an extension of the WSUS attack known since 2015 (but so far only worked against plaintext connections).

For the following reasons, we suggest to assign a new ESC number (ESC17) to such templates (allows Server Authentication, allows to supply SAN) in order to systematically identify and track these risks in Active Directory:
- The prerequisits are very similar to ESC1 and an incomplete mitigation of ESC1 could lead to the attack described above.
- Even though the attack does not exclusively target ADCS but merely uses it is a stepping stone, it will---if successful---result in an “escalation of privileges” based on a misconfiguration in an ADCS template.
- If a TLS-channel is established using a trusted certificate from an internal PKI, clients should be able to trust its authenticity. The possibility to impersonate arbitrary DNS names breaks this assumption and is therefore a (potentially security-relevant) misconfiguration of a certificate template.
    - For the particular case of WSUS, this means that the above-mentioned attack cannot be mitigated by configuring WSUS more securely but only by securing the vulnerable certificate template in ADCS.

<img width="1578" height="700" alt="esc17-certipy" src="https://github.com/user-attachments/assets/1d649434-3868-40ae-98a8-79cf688f4242" />

If this PR is accepted, the wiki must be updated as well. @ly4k we are happy to help with that.

Everyone, feel free to discuss what you think about this approach. We are open to suggestions.