### PR TITLE
Shadow credentials using SChannel

### DIFF
--- a/certipy/commands/parsers/shadow.py
+++ b/certipy/commands/parsers/shadow.py
@@ -96,6 +96,21 @@ def add_subparser(subparsers: argparse._SubParsersAction) -> Tuple[str, Callable
         help="Output file for saving certificate or results",
     )
 
+    # Certificate options
+    cert_group = subparser.add_argument_group("certificate options")
+    cert_group.add_argument(
+        "-pfx",
+        action="store",
+        metavar="pfx/p12 file name",
+        help="Path to certificate and private key (PFX/P12 format)",
+    )
+    cert_group.add_argument(
+        "-pfxpassword",
+        action="store",
+        metavar="password",
+        help="Password for the PFX/P12 file",
+    )
+
     # Add standard target arguments from shared module
     target.add_argument_group(subparser)
 

--- a/certipy/lib/target.py
+++ b/certipy/lib/target.py
@@ -139,6 +139,7 @@ class Target:
         # Authentication options
         principal = options.username if hasattr(options, "username") else None
         password = options.password if hasattr(options, "password") else None
+        pfx = options.pfx if hasattr(options, "pfx") else None
         hashes = options.hashes if hasattr(options, "hashes") else None
 
         do_kerberos = options.do_kerberos if hasattr(options, "do_kerberos") else False
@@ -196,6 +197,7 @@ class Target:
             and aes is None
             and no_pass is not True
             and do_kerberos is not True
+            and pfx is None
         ):
             from getpass import getpass
 


### PR DESCRIPTION
Currently, SChannel authentication is only implemented in the `auth` submodule of Certipy. However, the `shadow` module is interacting with LDAP and can be used using SChannel authentication.

This pull request was quickly made  and not fully tested but allows performing SChannel authentication. Feel free to edit it or make it better.

I can take more time and improve it with your pointers if you feel its necessary.