### PR TITLE
find: detect vulnerabilities across all principals, not just current user

### DIFF
--- a/certipy/commands/parsers/find.py
+++ b/certipy/commands/parsers/find.py
@@ -105,6 +105,11 @@ def add_subparser(subparsers: argparse._SubParsersAction) -> Tuple[str, Callable
         help="Show only vulnerable certificate templates based on nested group memberships",
     )
     find_group.add_argument(
+        "-user",
+        action="store_true",
+        help="Show only vulnerabilities exploitable by the current authenticated user",
+    )
+    find_group.add_argument(
         "-oids",
         action="store_true",
         help="Show OIDs (Issuance Policies) and their properties",


### PR DESCRIPTION
## Overview
Enhanced the `find` command's vulnerability detection to provide comprehensive attack surface analysis by identifying all exploitable principals per vulnerability, rather than limiting results to the current authenticated user.

fixes #353 
## Key Changes

### Comprehensive Vulnerability Detection
- **Before**: Vulnerabilities were only detected if exploitable by the current authenticated user
- **After**: All vulnerabilities are detected with a list of principals who can exploit each one

**New vulnerability output structure:**
```json
{
  "ESC1": {
    "description": "Enrollee supplies subject and template allows client authentication.",
    "principals": ["DOMAIN\\User1", "DOMAIN\\User2", "DOMAIN\\ITGroup"]
  }
}
```

### Principal Filtering
To keep output focused on actionable findings, well-known privileged groups (Domain Admins, Enterprise Admins, etc.) are excluded from the `principals` list. Since these groups inherently have dangerous permissions over templates (write, owner, etc.), including them would add noise without meaningful attack surface insight. Only custom/non-default groups and users are listed.