### PR TITLE
feat: add enumeration for Enrollment Agent Restrictions

### DIFF
--- a/certipy/commands/find.py
+++ b/certipy/commands/find.py
@@ -516,6 +516,7 @@ class Find:
             enforce_encrypt_icertrequest = "Unknown"
             disabled_extensions = "Unknown"
             security = None
+            enrollment_agent_restrictions = None
 
             if ca_configuration is not None:
                 active_policy = ca_configuration.active_policy
@@ -546,6 +547,10 @@ class Find:
 
                 security = ca_configuration.security
 
+                enrollment_agent_restrictions = (
+                    ca_configuration.enrollment_agent_restrictions
+                )
+
             # Update properties
             ca_properties.update(
                 {
@@ -555,6 +560,7 @@ class Find:
                     "enforce_encrypt_icertrequest": enforce_encrypt_icertrequest,
                     "disabled_extensions": disabled_extensions,
                     "security": security,
+                    "enrollment_agent_restrictions": enrollment_agent_restrictions,
                 }
             )
 
@@ -1122,6 +1128,24 @@ class Find:
             # Create entry with properties and permissions
             entry = OrderedDict()
             entry = self.get_ca_properties(ca, entry)
+
+            # Add Enrollment Agent Restrictions if present
+            ea_restrictions = ca.get("enrollment_agent_restrictions")
+            if ea_restrictions is not None:
+                restrictions_output = OrderedDict()
+                for restriction in ea_restrictions:
+                    agent_name = self.connection.lookup_sid(restriction.agent).get(
+                        "name"
+                    )
+                    target_names = [
+                        self.connection.lookup_sid(t).get("name")
+                        for t in restriction.targets
+                    ]
+                    restrictions_output[agent_name] = {
+                        "Template": restriction.template,
+                        "Targets": target_names if target_names else ["<All>"],
+                    }
+                entry["Enrollment Agent Restrictions"] = restrictions_output
 
             # Add permissions
             permissions = self.get_ca_permissions(ca)


### PR DESCRIPTION
**Subject:** feat: add enumeration for Enrollment Agent Restrictions

Description:
This PR adds the ability to enumerate Enrollment Agent Restrictions from the CA configuration.

**Why it matters:**
This is useful for ESC3 scenarios. While Certipy could previously identify Enrollment Agents, it couldn't see their specific constraints. This update reveals:
- Who the agent can act on behalf of.
- Which templates they are allowed to use.

before:
<img width="783" height="461" alt="image" src="https://github.com/user-attachments/assets/f30867cd-df42-463d-8382-1c95e24d1e11" />

now:

<img width="850" height="551" alt="image" src="https://github.com/user-attachments/assets/18f602a0-da7d-4455-a704-c8740af9a418" />
