### PR TITLE
Fix output path handling to preserve directory structure (fixes #351)

### DIFF
--- a/certipy/lib/files.py
+++ b/certipy/lib/files.py
@@ -31,8 +31,12 @@ def try_to_save_file(
     """
     logging.debug(f"Attempting to write data to {output_path!r}")
 
-    # Clean up the output path
-    output_path = output_path.replace("\\", "_").replace("/", "_").replace(":", "_")
+    # Clean up only the filename part, not the directory path
+    directory = os.path.dirname(output_path)
+    filename = os.path.basename(output_path)
+    # Sanitize only the filename to remove invalid characters
+    filename = filename.replace(":", "_")
+    output_path = os.path.join(directory, filename) if directory else filename
 
     # Handle file existence check and overwrite confirmation
     output_path = _handle_file_exists(output_path)


### PR DESCRIPTION
The output_path sanitization was too aggressive, replacing all path separators (/ and \) with underscores. This prevented users from specifying full paths for output files.

Changed to only sanitize the filename component while preserving the directory path. Only colons are replaced in the filename to handle invalid characters on Windows.

Fixes #351