### PR TITLE
fix: handle empty username in NTLM relay CSR generation

### DIFF
--- a/certipy/commands/find.py
+++ b/certipy/commands/find.py
@@ -1082,7 +1082,7 @@ class Find:
                 continue
 
             # Get template vulnerabilities
-            (vulnerabilities, remarks, enrollable_principals, acl_principals) = (
+            vulnerabilities, remarks, enrollable_principals, acl_principals = (
                 self.get_template_vulnerabilities(template)
             )
 
@@ -1129,7 +1129,7 @@ class Find:
                 entry["Permissions"] = permissions
 
             # Add vulnerabilities
-            (vulnerabilities, remarks, enrollable_principals, acl_principals) = (
+            vulnerabilities, remarks, enrollable_principals, acl_principals = (
                 self.get_ca_vulnerabilities(ca)
             )
 
@@ -1156,7 +1156,7 @@ class Find:
         if self.oids:
             for oid in oids:
                 # Get OID vulnerabilities
-                (vulnerabilities, acl_principals) = self.get_oid_vulnerabilities(oid)
+                vulnerabilities, acl_principals = self.get_oid_vulnerabilities(oid)
 
                 # Skip if only showing vulnerable OIDs and this one isn't
                 if self.vuln and not vulnerabilities:

--- a/certipy/commands/relay.py
+++ b/certipy/commands/relay.py
@@ -518,6 +518,18 @@ class ADCSHTTPAttackClient(ProtocolAttack):
         """
         Request a new certificate for the relayed user.
         """
+        # Validate username before proceeding — an empty username from the
+        # NTLM response will cause CSR generation to fail if no explicit
+        # subject DN was provided.
+        if not self.username and not self.adcs_relay.subject:
+            logging.error(
+                "Relayed NTLM authentication returned an empty username "
+                f"(authenticated as {self.client.user!r}). "
+                "Cannot generate CSR without a valid subject. "
+                "Use '-subject CN=<target>' to specify an explicit subject DN."
+            )
+            return
+
         # Choose appropriate template based on username
         template = self.config.template
         if template is None:
@@ -707,6 +719,18 @@ class ADCSRPCAttackClient(ProtocolAttack):
         Returns:
             Tuple of (PFX data, filename) on success, False on failure
         """
+        # Validate username before proceeding — an empty username from the
+        # NTLM response will cause CSR generation to fail if no explicit
+        # subject DN was provided.
+        if not self.username and not self.adcs_relay.subject:
+            logging.error(
+                "Relayed NTLM authentication returned an empty username "
+                f"(authenticated as {self.username!r}@{self.domain!r}). "
+                "Cannot generate CSR without a valid subject. "
+                "Use '-subject CN=<target>' to specify an explicit subject DN."
+            )
+            return False
+
         # Choose appropriate template based on username
         template = self.config.template
         if template is None:

--- a/certipy/lib/certificate.py
+++ b/certipy/lib/certificate.py
@@ -806,6 +806,17 @@ def create_csr(
     if subject:
         subject_name = get_subject_from_str(subject)
     else:
+        # Validate username before using it as CN — x509 NameAttribute
+        # requires a non-empty value (length >= 1 and <= 64).
+        # This can happen during relay attacks when the NTLM response
+        # contains an empty user_name field.
+        if not username or not username.strip():
+            raise ValueError(
+                "Cannot create CSR: username is empty. "
+                "The relayed NTLM authentication did not contain a valid username. "
+                "Use the '-subject' option to specify an explicit subject DN, "
+                "or ensure the relayed connection provides a valid username."
+            )
         subject_name = x509.Name(
             [
                 x509.NameAttribute(NameOID.COMMON_NAME, username.capitalize()),

--- a/certipy/lib/req.py
+++ b/certipy/lib/req.py
@@ -554,8 +554,17 @@ def web_request(
     )
 
     # Send certificate request
+    # Certificate issuance can take significantly longer than the NTLM auth
+    # handshake, so we use an extended timeout for the POST request.
+    # Use at least 60 seconds, or the session's configured read timeout if larger.
+    session_read_timeout = getattr(session.timeout, "read", 10) or 10
+    cert_request_timeout = max(session_read_timeout, 60)
     try:
-        res = session.post("/certsrv/certfnsh.asp", data=params)
+        res = session.post(
+            "/certsrv/certfnsh.asp",
+            data=params,
+            timeout=cert_request_timeout,
+        )
         content = res.text
 
         # Handle HTTP errors
@@ -598,6 +607,13 @@ def web_request(
 
         return None
 
+    except httpx.ReadTimeout:
+        logging.error(
+            f"Certificate request timed out after {cert_request_timeout}s waiting for "
+            "AD CS to respond. The CA may be slow or under load. "
+            "Try increasing the timeout with '-timeout <seconds>' (e.g., -timeout 120)"
+        )
+        return None
     except Exception as e:
         logging.error(f"Error during web certificate request: {e}")
         handle_error()


### PR DESCRIPTION
## Summary

Fixes #342 — `ValueError: Attribute's length must be >= 1 and <= 64, but it was 0` during NTLM relay attacks.

## Root Cause

When relayed NTLM authentication returns an **empty `user_name` field** (observable in logs as `Authenticating against ... as /`), impacket's `ProtocolAttack.__init__` splits the username string on `/` and produces `self.username = ""`. This empty string is then passed to `create_csr()`, where `x509.NameAttribute(NameOID.COMMON_NAME, "".capitalize())` crashes because the cryptography library requires CN length >= 1.

This commonly occurs with:
- Machine account coercion via Kerberos (`--use-kcache` / coerce_plus)
- Anonymous or null NTLM sessions
- Certain NTLM relay scenarios where the user_name field is not populated

## Changes

### 1. Early username validation in relay attack clients (`relay.py`)

Both `ADCSHTTPAttackClient._request_certificate()` and `ADCSRPCAttackClient.request()` now detect empty usernames **before** CSR generation and log a clear, actionable error:

```
Relayed NTLM authentication returned an empty username (authenticated as '\\'). 
Cannot generate CSR without a valid subject. 
Use '-subject CN=<target>' to specify an explicit subject DN.
```

This allows the relay server to **continue listening** for new connections instead of crashing.

### 2. Defensive guard in `create_csr()` (`certificate.py`)

Added explicit validation in `create_csr()` as a safety net — raises a descriptive `ValueError` with guidance instead of the cryptic cryptography library error.

### 3. Extended timeout for certificate POST requests (`req.py`)

The `session.post("/certsrv/certfnsh.asp")` call was inheriting the session's 10-second default timeout, which is insufficient for AD CS certificate issuance (the CA can take 30-60+ seconds under load). Now:

- Certificate POST uses a **minimum 60-second timeout** (or the session's configured timeout if larger)
- Explicit `httpx.ReadTimeout` handler with actionable error message suggesting `-timeout <seconds>`

## Workaround

Affected users can work around the empty username issue by specifying an explicit subject:

```bash
certipy relay -target http://ca.domain.com -subject "CN=TargetMachine"
```

## Testing

Verified that:
- ✅ Empty username without `-subject` raises clear error (not cryptic crash)
- ✅ Empty username **with** `-subject CN=...` works correctly
- ✅ Normal usernames are unaffected
- ✅ Timeout escalation logic works (10s session → 60s POST; 120s session → 120s POST)
- ✅ All imports resolve correctly